### PR TITLE
Chore Fix types in jest, bump jest packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,26 +22,25 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.1",
-    "jest": "^27.5.1",
+    "jest": "^28.1.0",
+    "jest-mock": "^28.1.0",
     "lint-staged": "^13.0.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
-    "ts-jest": "27.1.4",
+    "ts-jest": "^28.0.2",
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=7"
+    "node": ">=16.6.0",
+    "npm": ">=7.0.0"
   },
   "files": [
     "dist"
   ],
   "husky": {
     "hooks": {
-      "pre-commit": [
-        "lint-staged"
-      ]
+      "pre-commit": "lint-staged"
     }
   },
   "keywords": [

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -1,7 +1,6 @@
 import * as DiscordTransport from "../DiscordTransport"
-import { mocked } from "ts-jest/utils"
+import { mocked } from "jest-mock"
 import * as Discord from "discord.js"
-import { ChannelType } from "discord-api-types/payloads/v9/channel"
 
 jest.mock("discord.js")
 
@@ -73,7 +72,7 @@ describe("DiscordTransport", () => {
     it("handles (undefined, undefined) correctly", () => {
       const discordChannel = new Discord.TextChannel(mockGuild, {
         id: "mock-channel-id",
-        type: ChannelType.GuildText,
+        type: Discord.BaseGuildTextChannel,
       })
       transport.discordChannel = discordChannel
 
@@ -85,7 +84,7 @@ describe("DiscordTransport", () => {
     it("handles (string, undefined) correctly", () => {
       const discordChannel = new Discord.TextChannel(mockGuild, {
         id: "mock-channel-id",
-        type: ChannelType.GuildText,
+        type: Discord.BaseGuildTextChannel,
       })
       mocked(discordChannel.send).mockImplementation(() =>
         Promise.resolve(undefined)
@@ -100,7 +99,7 @@ describe("DiscordTransport", () => {
     it("handles send() throwing an error", (done) => {
       const discordChannel = new Discord.TextChannel(mockGuild, {
         id: "mock-channel-id",
-        type: ChannelType.GuildText,
+        type: Discord.BaseGuildTextChannel,
       })
       const fakeError = new Error("fake error")
       mocked(discordChannel.send).mockImplementation(() =>
@@ -120,7 +119,7 @@ describe("DiscordTransport", () => {
       const callback = jest.fn()
       const discordChannel = new Discord.TextChannel(mockGuild, {
         id: "mock-channel-id",
-        type: ChannelType.GuildText,
+        type: Discord.BaseGuildTextChannel,
       })
       mocked(discordChannel.send).mockImplementation(() =>
         Promise.resolve(undefined)


### PR DESCRIPTION
Newer version of discord has an updated client type, that is not compatible with the older version, with 13.7+ i recommend a new minor version release.

Chores: 
- [x] Bumps Jest to latest
- [x] Corrects minor items in package.json
- [x] corrects discord types for tests