### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Logging via Prototype-less Objects

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Discord API rejects messages with embed field names >256 chars, values >1024 chars, or >25 fields. The Winston transport failed to enforce these limits, meaning maliciously large logs (e.g., from an attacker) would be rejected by Discord and never recorded, hiding traces of the attack.
 **Learning:** Logging integrations that rely on external APIs with strict length/size limits must enforce those limits locally (e.g., via truncation) to prevent "Denial of Logging" attacks where an attacker intentionally generates oversized logs to bypass monitoring.
 **Prevention:** Always sanitize and truncate log fields before sending them to external APIs with known constraints (like Discord, Slack, etc.).
+
+## 2025-02-12 - Denial of Logging via Prototype-less Objects
+**Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
+**Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
+**Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.

--- a/src/LogHandlers.ts
+++ b/src/LogHandlers.ts
@@ -57,6 +57,18 @@ export const handlePrimitive = (info: Primitive): string => {
 const capitalize = (str: string): string =>
   str.charAt(0).toLocaleUpperCase() + str.slice(1)
 
+const safeStringify = (value: any): string => {
+  try {
+    return String(value)
+  } catch (err) {
+    try {
+      return JSON.stringify(value) || "[object Object]"
+    } catch (err2) {
+      return "[object Object]"
+    }
+  }
+}
+
 export const handleLogform = (
   info: TransformableInfo,
   level?: string
@@ -85,12 +97,13 @@ export const handleLogform = (
       if (info[field]) {
         const capitalizedField = capitalize(field)
         const value = info[field]
+        const stringifiedValue = safeStringify(value)
 
-        logMessageParts.push(`${capitalizedField}: ${value}`)
+        logMessageParts.push(`${capitalizedField}: ${stringifiedValue}`)
 
         if (fieldCount < 25 && totalEmbedLength < 6000) {
           let truncatedName = capitalizedField.substring(0, 256)
-          let truncatedValue = value.toString().substring(0, 1024)
+          let truncatedValue = stringifiedValue.substring(0, 1024)
 
           // Ensure we don't exceed the 6000 character total limit for embeds
           const availableSpace = 6000 - totalEmbedLength

--- a/src/tests/LogHandlers.test.ts
+++ b/src/tests/LogHandlers.test.ts
@@ -276,6 +276,57 @@ describe("LogHandlers", () => {
       ])
     })
 
+    it("handles TransformableInfo fields containing prototype-less objects safely", () => {
+      const info: logform.TransformableInfo = {
+        level: "info",
+        message: "hello",
+        badObject: Object.create(null),
+      }
+
+      const result = handleLogform(info, "info")
+      expect(result).toBeDefined()
+
+      const resultTuple = result as [string, MessageEmbed]
+      const [messageContent, embed] = resultTuple
+
+      expect(messageContent).toContain("BadObject: {}")
+      expect(embed.fields).toContainEqual({
+        name: "BadObject",
+        value: "{}",
+        inline: true,
+      })
+    })
+
+    it("handles TransformableInfo fields containing objects with throwing stringification safely", () => {
+      const throwingObject = {
+        toString: () => {
+          throw new Error("Boom")
+        },
+        toJSON: () => {
+          throw new Error("Boom")
+        },
+      }
+
+      const info: logform.TransformableInfo = {
+        level: "info",
+        message: "hello",
+        badObject: throwingObject,
+      }
+
+      const result = handleLogform(info, "info")
+      expect(result).toBeDefined()
+
+      const resultTuple = result as [string, MessageEmbed]
+      const [messageContent, embed] = resultTuple
+
+      expect(messageContent).toContain("BadObject: [object Object]")
+      expect(embed.fields).toContainEqual({
+        name: "BadObject",
+        value: "[object Object]",
+        inline: true,
+      })
+    })
+
     it("truncates fields and limits to 25 fields for Discord limits", () => {
       const longName = "A".repeat(300)
       const longValue = "B".repeat(2000)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Direct string interpolation of arbitrary log data caused unhandled exceptions and Node.js process crashes when objects lacked a `.toString()` method (e.g., `Object.create(null)`) or intentionally threw errors during serialization. This enables "Denial of Logging" attacks where maliciously crafted payloads bypass monitoring entirely by crashing the transport.
🎯 Impact: Complete bypass of logging capabilities and potentially crashing the underlying application whenever a crafted object is logged.
🔧 Fix: Implemented `safeStringify` fallback mechanism inside `src/LogHandlers.ts` using `try-catch` blocks and `JSON.stringify` to safely serialize objects before logging. Replaced `value.toString()` with `safeStringify(value)`.
✅ Verification: Successfully added and ran Unit tests in `src/tests/LogHandlers.test.ts` testing prototype-less and throwing objects. Verified that Node.js no longer crashes and outputs the expected fallback values.

---
*PR created automatically by Jules for task [17849925261444114268](https://jules.google.com/task/17849925261444114268) started by @robertsmieja*