### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Logging via Unbounded String Primitives

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-03-31 - Denial of Logging via Unbounded String Primitives
+**Vulnerability:** Discord API rejects messages with content exceeding 2000 characters. The Winston transport enforced this limit for object/logform payloads via embeddings but failed to truncate unbounded string primitive logs. Thus, maliciously large primitive logs (e.g., from an attacker) would be rejected by Discord and silently hidden.
+**Learning:** External API message content size limits must be comprehensively enforced across all input code paths, not just formatted objects. Silent logging failures on large input strings can hide traces of attacks.
+**Prevention:** Always check message bounds limits (e.g. 2000 characters) across all execution paths prior to invoking logging mechanisms dependent on third-party integrations with strict restrictions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4699,9 +4699,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6577,9 +6577,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -8580,9 +8580,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -61,7 +61,10 @@ export class DiscordTransport extends TransportStream {
             embeds: [embed],
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Discord Message Content Limit: 2000 characters
+          // Documented at: https://discord.com/developers/docs/resources/message#embed-object-embed-limits
+          const truncatedMessage = String(logMessage).substring(0, 2000)
+          messagePromise = this.discordChannel.send(truncatedMessage)
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -138,6 +138,58 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith("log me!")
     })
 
+    it("truncates long strings to 2000 characters", () => {
+      const fakeDiscordChannel = {
+        send: vi.fn(async () => {
+          return {}
+        }) as unknown,
+      } as Partial<Discord.TextChannel>
+      transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
+
+      const veryLongString = "A".repeat(3000)
+      transport.log(veryLongString, undefined)
+
+      const mockSend = fakeDiscordChannel.send as MockedFunction<
+        Discord.TextChannel["send"]
+      >
+
+      expect(mockSend).toHaveBeenCalledWith("A".repeat(2000))
+    })
+
+    it("handles non-string primitives safely without truncation errors", () => {
+      const fakeDiscordChannel = {
+        send: vi.fn(async () => {
+          return {}
+        }) as unknown,
+      } as Partial<Discord.TextChannel>
+      transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
+
+      transport.log(12345, undefined)
+
+      const mockSend = fakeDiscordChannel.send as MockedFunction<
+        Discord.TextChannel["send"]
+      >
+
+      expect(mockSend).toHaveBeenCalledWith("12345")
+    })
+
+    it("handles string primitives less than 2000 characters correctly", () => {
+      const fakeDiscordChannel = {
+        send: vi.fn(async () => {
+          return {}
+        }) as unknown,
+      } as Partial<Discord.TextChannel>
+      transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
+
+      transport.log("short string", undefined)
+
+      const mockSend = fakeDiscordChannel.send as MockedFunction<
+        Discord.TextChannel["send"]
+      >
+
+      expect(mockSend).toHaveBeenCalledWith("short string")
+    })
+
     it("handles log messages with embeds correctly", () => {
       const fakeDiscordChannel = {
         send: vi.fn(async () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded string primitive logs could exceed Discord's API limits (2000 chars), causing the Discord API to reject them completely. This creates a Denial of Logging vector where attackers could intentionally create huge strings to prevent their activities from being recorded.
🎯 **Impact:** Complete failure to deliver logs to Discord, effectively hiding traces of an attack or hiding critical system failures.
🔧 **Fix:** Coerce the log payload to a string and enforce a `.substring(0, 2000)` truncation at the final Transport layer boundary prior to calling `discordChannel.send()`.
✅ **Verification:** Added Vitest tests for strings > 2000 characters to verify safe truncation functionality, preserving other primitives, and ensuring no dead-code branches were left behind. Tests, type checks, and linting were locally executed and pass with 100% of the branch thresholds intact.

---
*PR created automatically by Jules for task [6941584124672340405](https://jules.google.com/task/6941584124672340405) started by @robertsmieja*