### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Logging via Unbounded String Inputs

### DIFF
--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -61,7 +61,10 @@ export class DiscordTransport extends TransportStream {
             embeds: [embed],
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Discord Message Content Limit: 2000 characters
+          // https://discord.com/developers/docs/resources/message#create-message
+          const content = String(logMessage).substring(0, 2000)
+          messagePromise = this.discordChannel.send(content)
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -138,6 +138,24 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith("log me!")
     })
 
+    it("truncates log messages without embeds to 2000 characters", () => {
+      const fakeDiscordChannel = {
+        send: vi.fn(async () => {
+          return {}
+        }) as unknown,
+      } as Partial<Discord.TextChannel>
+      transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
+
+      const longString = "A".repeat(3000)
+      transport.log(longString, undefined)
+
+      const mockSend = fakeDiscordChannel.send as MockedFunction<
+        Discord.TextChannel["send"]
+      >
+
+      expect(mockSend).toHaveBeenCalledWith("A".repeat(2000))
+    })
+
     it("handles log messages with embeds correctly", () => {
       const fakeDiscordChannel = {
         send: vi.fn(async () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded log messages via DiscordTransport could exceed Discord's 2000 character limit, causing a "Bad Request" rejection from the Discord API. An attacker could intentionally generate oversized inputs to trigger these errors, silently failing the transport layer and enabling "Denial of Logging".
🎯 **Impact:** Potential loss of visibility into critical application behavior and attacks if large stack traces or inputs hide subsequent activity by causing errors.
🔧 **Fix:** Coerced log payloads to strings and applied `.substring(0, 2000)` prior to execution of `send()` inside the transport layer `log()` method to conform to Discord API limits.
✅ **Verification:** Added a Vitest test ensuring messages >2000 characters are correctly truncated before `send()` is called. Tests and lint checks pass.

---
*PR created automatically by Jules for task [11589503317681555890](https://jules.google.com/task/11589503317681555890) started by @robertsmieja*