### PR TITLE
🛡️ Sentinel: [HIGH] Fix unhandled promise rejection DoS risk on login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Denial of Logging via Unhandled Promise Rejection
+**Vulnerability:** Calling `this.discordClient.login(discordToken)` without a `.catch()` block causes an unhandled promise rejection if the token is invalid (e.g. `Error [TOKEN_INVALID]`). In modern Node.js versions, unhandled promise rejections cause the process to crash, which is a Denial of Service (DoS) risk.
+**Learning:** External API initialization or authentication calls that return Promises must always have their rejections handled gracefully (e.g., by logging a warning or emitting an event) to avoid process termination.
+**Prevention:** Always append `.catch()` blocks to asynchronous external operations, especially during transport initialization.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -33,7 +33,9 @@ export class DiscordTransport extends TransportStream {
           this.discordClient.on("error", (error) => {
             this.emit("warn", error)
           })
-          this.discordClient.login(discordToken)
+          this.discordClient.login(discordToken).catch((error) => {
+            this.emit("warn", error)
+          })
         }
       }
 

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -34,10 +34,14 @@ describe("DiscordTransport", () => {
       const fakeChannelManager = {} as Partial<Discord.ChannelManager>
 
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("fake-token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
       fakeDiscordClient.channels = fakeChannelManager as Discord.ChannelManager
+
+      vi.spyOn(Discord, "Client").mockImplementationOnce(function (this: any) {
+        return fakeDiscordClient as any
+      } as any)
 
       const transport = new DiscordTransport(options)
 
@@ -67,7 +71,7 @@ describe("DiscordTransport", () => {
 
       // Recreate how discordClient is handled in the previous test
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("fake-token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Calling `this.discordClient.login(discordToken)` without a `.catch()` block causes an unhandled promise rejection if the token is invalid (e.g., `Error [TOKEN_INVALID]`) or the network request fails. In modern Node.js versions, unhandled promise rejections cause the process to crash entirely. Because this is a logging transport, crashing the entire application over a logging connection failure is a severe Denial of Service (DoS) risk.
🎯 Impact: An invalid API token or network failure during logger initialization would terminate the entire Node.js host process.
🔧 Fix: Appended a `.catch()` block to `this.discordClient.login()` to gracefully catch the rejection and emit a `warn` event instead, preventing process termination. This perfectly mirrors the existing `error` event handler behavior right above it. Updated the corresponding unit tests to correctly mock the `.login()` promise.
✅ Verification: Ran `npm run test` and manually verified that instantiating `DiscordTransport` with an invalid token no longer crashes the process.

---
*PR created automatically by Jules for task [2283479655870755577](https://jules.google.com/task/2283479655870755577) started by @robertsmieja*