### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Logging via toString() and update brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4699,9 +4699,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6577,9 +6577,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -8580,9 +8580,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"

--- a/src/LogHandlers.ts
+++ b/src/LogHandlers.ts
@@ -158,9 +158,17 @@ export const handleObject = (
     return info.stack
   } else if (
     typeof info?.toString === "function" &&
-    info.toString !== Object.toString
+    info.toString !== Object.prototype.toString
   ) {
-    return info.toString()
+    try {
+      return info.toString()
+    } catch (err) {
+      try {
+        return JSON.stringify(info)
+      } catch (err2) {
+        return "[object Object]"
+      }
+    }
   } else {
     try {
       // this will call toJSON on the object, if it exists

--- a/src/tests/LogHandlers.test.ts
+++ b/src/tests/LogHandlers.test.ts
@@ -494,6 +494,37 @@ describe("LogHandlers", () => {
       expect(handleObject(testObject)).toBe(JSON.stringify(testObject))
     })
 
+    it("handles objects with a toString property that throws", () => {
+      const testObject = {
+        toString: () => {
+          throw new Error("Throw in toString")
+        },
+      }
+      expect(handleObject(testObject)).toBe(JSON.stringify(testObject))
+    })
+
+    it("handles objects with a toString property that throws and a toJSON property that throws", () => {
+      const testObject = {
+        toString: () => {
+          throw new Error("Throw in toString")
+        },
+        toJSON: () => {
+          throw new Error("Throw in toJSON")
+        },
+      }
+      expect(handleObject(testObject)).toBe("[object Object]")
+    })
+
+    it("handles objects with a toString property that throws and a circular reference", () => {
+      const testObject: any = {
+        toString: () => {
+          throw new Error("Throw in toString")
+        },
+      }
+      testObject.testObject = testObject
+      expect(handleObject(testObject)).toBe("[object Object]")
+    })
+
     it("handles circular objects without throwing", () => {
       const testObject: any = Object.create(null)
       testObject.myself = testObject
@@ -513,7 +544,7 @@ describe("LogHandlers", () => {
     it("handles object", () => {
       const testObject = { someProperty: "someValue" }
 
-      expect(handleInfo(testObject)).toBe(testObject.toString())
+      expect(handleInfo(testObject)).toBe(JSON.stringify(testObject))
     })
   })
 })


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** 
1. **Denial of Logging via `toString()`:** The `handleObject` function incorrectly compared `info.toString` to `Object.toString` instead of `Object.prototype.toString`. Furthermore, it did not safely handle custom `toString()` methods that might throw errors. Maliciously crafted objects (e.g. from user input) could crash the logging pipeline and effectively bypass logging/auditing.
2. **ReDoS Vulnerability:** The `brace-expansion` dependency had a known ReDoS (Regular Expression Denial of Service) vulnerability.

🎯 **Impact:** 
- A crash in the logging layer leads to missing audit trails, and if the crash is unhandled, it will terminate the Node.js process (Denial of Service).
- The ReDoS vulnerability in `brace-expansion` could lead to CPU exhaustion.

🔧 **Fix:** 
1. Modified `src/LogHandlers.ts` to properly check `info.toString !== Object.prototype.toString` and wrap the `toString()` call in a `try...catch` block. If `toString()` throws, it gracefully falls back to `JSON.stringify()`, and if that also throws, it defaults to `"[object Object]"`.
2. Ran `npm audit fix` to update `brace-expansion` to version 1.1.13, resolving the vulnerability.

✅ **Verification:** 
Added unit tests in `src/tests/LogHandlers.test.ts` to explicitly test objects with throwing `toString()`, throwing `toJSON()`, and throwing `toString()` with circular references. All tests, linting, and typechecks pass successfully.

---
*PR created automatically by Jules for task [4491142263143207006](https://jules.google.com/task/4491142263143207006) started by @robertsmieja*