### PR TITLE
🛡️ Sentinel: HIGH Fix Denial of Logging via Primitive `in` Operator DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Denial of Logging via Primitive `in` Operator
+**Vulnerability:** The `isTransformableInfo` type guard used the `in` operator to check for properties (e.g., `"level" in info`) without explicitly verifying that the `info` object was actually an object. Passing primitives like a `string`, `number`, or `boolean` caused the `in` operator to throw a runtime `TypeError`, crashing the Node.js process.
+**Learning:** Type guards that accept `unknown` or `any` input cannot blindly use the `in` operator. Because unhandled exceptions in asynchronous logging paths can crash the application, an attacker could supply a primitive string that leads to a "Denial of Logging" DoS scenario.
+**Prevention:** Always verify that a variable is a non-null object (`typeof info === 'object' && info !== null`) before using the `in` operator in type guards or validation logic.

--- a/src/LogHandlers.ts
+++ b/src/LogHandlers.ts
@@ -6,7 +6,12 @@ import { LogLevel, LogLevelToColor } from "./LogLevels"
 export const isTransformableInfo = (
   info: unknown
 ): info is TransformableInfo => {
-  return Boolean(info && "level" in (info as any) && "message" in (info as any))
+  return Boolean(
+    typeof info === "object" &&
+      info !== null &&
+      "level" in (info as any) &&
+      "message" in (info as any)
+  )
 }
 
 const sortFields = (fields: string[]): string[] => {

--- a/src/tests/LogHandlers.test.ts
+++ b/src/tests/LogHandlers.test.ts
@@ -47,12 +47,24 @@ describe("LogHandlers", () => {
       expect(isTransformableInfo(0)).toBe(false)
     })
 
+    it("handles non-zero numbers", () => {
+      expect(isTransformableInfo(123)).toBe(false)
+    })
+
     it("handles false", () => {
       expect(isTransformableInfo(false)).toBe(false)
     })
 
+    it("handles true", () => {
+      expect(isTransformableInfo(true)).toBe(false)
+    })
+
     it(`handles ""`, () => {
       expect(isTransformableInfo("")).toBe(false)
+    })
+
+    it(`handles non-empty strings`, () => {
+      expect(isTransformableInfo("hello")).toBe(false)
     })
 
     it("handles an empty object", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `isTransformableInfo` type guard in `src/LogHandlers.ts` blindly applied the `in` operator to verify properties (`"level" in info`) based only on truthiness (`Boolean(info)`). If a truthy primitive (like `"hello"`, `123`, or `true`) was evaluated, the `in` operator threw a runtime `TypeError` (`Cannot use 'in' operator to search for 'level' in...`). 
🎯 Impact: Unhandled exceptions in logging integrations bypass transport error handling, causing the main Node.js process to crash. An attacker could intentionally trigger a logging statement with a primitive value to execute a "Denial of Logging" Denial of Service attack.
🔧 Fix: Explicitly assert that the input is a non-null object via `typeof info === "object" && info !== null` before invoking the `in` operator. Added unit tests for primitives to guarantee stability.
✅ Verification: Ran `npm run test`, `npm run lint`, and `npm run typecheck` which all completed successfully. Added targeted test coverage for string, number, and boolean primitives in `LogHandlers.test.ts`.

---
*PR created automatically by Jules for task [12217677758429840875](https://jules.google.com/task/12217677758429840875) started by @robertsmieja*