### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The logging framework sent string payloads directly to the Discord API without restricting mentions. This allowed a malicious actor to inject content like `@everyone` or `@here` into log messages (e.g., via a controlled username or input field), causing the Discord bot to mass-ping the server whenever that log was transported.
+**Learning:** External logging transports that integrate with chat platforms must sanitize or restrict chat-specific formatting and mention syntax in the transported logs, as logs often contain untrusted user input.
+**Prevention:** Always enforce `allowedMentions: { parse: [] }` in the Discord message payload options to ensure that raw text content is never parsed into actual mentions by the Discord API.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Prevent arbitrary pings via log injection
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Prevent arbitrary pings via log injection
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection / Unrestricted Mentions. The logging framework passed string payloads directly to the Discord API. This allowed untrusted user input embedded in logs (e.g., a username or user-submitted value) containing Discord mention syntax like `@everyone` or `@here` to actually trigger those mentions in the target Discord channel.
🎯 **Impact:** Malicious actors could intentionally construct payloads to flood the Discord server with mass pings every time a specific log was emitted, causing significant disruption or abuse of the logging channel.
🔧 **Fix:** Passed the `allowedMentions: { parse: [] }` option to the Discord client's `send()` method across both array (embed) and primitive string log paths. This tells the Discord API to treat all mention syntax strictly as raw text rather than executable mentions.
✅ **Verification:** Verified by running the entire Vitest suite (`npm run test`) after updating the `DiscordTransport.test.ts` expectations to assert that the `mockSend` calls receive `{ content, allowedMentions: { parse: [] } }`. All tests and compilation checks (`npm run build`, `npm run lint`) pass.

---
*PR created automatically by Jules for task [3435249753412497268](https://jules.google.com/task/3435249753412497268) started by @robertsmieja*