### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions via Log Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** Log messages sent to Discord via `discordChannel.send()` were not sanitizing user-provided content. This allowed an attacker to perform unrestricted Discord mentions (e.g., `@everyone`, `@here`) if their input was included in the log message, causing a Denial of Service or unintended spam in the Discord channel.
+**Learning:** External APIs like Discord.js will parse message content for mentions by default. When forwarding logs to such APIs, explicit restrictions must be applied to the message payloads to prevent malicious input from abusing mention functionality.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in the message options for all log messages and payloads containing embeds to restrict parsing of mentions, ensuring unintended mentions cannot be triggered by user-controlled log data.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log messages sent to Discord via `discordChannel.send()` were not sanitizing user-provided content. This allowed an attacker to perform unrestricted Discord mentions (e.g., `@everyone`, `@here`) if their malicious input was included in the log message.
🎯 **Impact:** Could lead to unintended spam or Denial of Service in the Discord channel due to an attacker pinging multiple members or roles.
🔧 **Fix:** Explicitly set `allowedMentions: { parse: [] }` in the message options for all log messages and payloads containing embeds to restrict parsing of mentions, ensuring unintended mentions cannot be triggered by user-controlled log data.
✅ **Verification:** Verified locally that all `npm run typecheck`, `npm run test`, and `npm run lint` commands pass and the new tests assert `allowedMentions` is explicitly provided.

---
*PR created automatically by Jules for task [13661622937924272453](https://jules.google.com/task/13661622937924272453) started by @robertsmieja*