### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted mention log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Mentions
+**Vulnerability:** Discord API parses text for mentions by default. Because the Winston transport did not restrict mention parsing in its `send` options, maliciously crafted logs containing strings like `@everyone`, `@here`, or `<@!userID>` would trigger actual push notifications/mentions in Discord, leading to severe annoyance or denial-of-service via notification spam.
+**Learning:** Any text being sent to a chat platform (like Discord) from an untrusted source (e.g. log files or user input recorded in logs) must explicitly disable mention parsing at the transport layer to prevent unintentional pings.
+**Prevention:** Always set `allowedMentions: { parse: [] }` when sending Discord messages that originate from or contain arbitrary log data.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Discord API parses text for mentions by default. Because the Winston transport did not restrict mention parsing in its `send` options, maliciously crafted logs containing strings like `@everyone`, `@here`, or `<@!userID>` would trigger actual push notifications/mentions in Discord.
🎯 Impact: This could lead to severe annoyance, notification spam, or a denial-of-service via log injection if untrusted user input is logged.
🔧 Fix: Explicitly added `allowedMentions: { parse: [] }` to all `discord.js` API `send` calls in `DiscordTransport.ts` to prevent unintentional pings. Updated the text-only logging path to use an object payload (`send({ content: logMessage, ... })`) to support this natively.
✅ Verification: Ran the full test suite (`npm run test`) and `npm run check`. Updated assertions in `DiscordTransport.test.ts` to ensure the `allowedMentions` options are being passed properly to mocked Discord components.

---
*PR created automatically by Jules for task [2368590588209127858](https://jules.google.com/task/2368590588209127858) started by @robertsmieja*