### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Discord Mentions in Logs
+**Vulnerability:** The Discord Winston transport did not restrict the mentions parsing in messages it sent to Discord channels. This allowed any logged message (such as user input or errors containing @everyone or @here) to trigger a notification ping to all users in the channel, resulting in a potential Denial of Service (DoS) or harassment attack via log injection.
+**Learning:** External user inputs that end up in system logs must not be able to trigger functionality in downstream viewing platforms (like Discord mentions). The default behavior of Discord's API allows mentions, so they must be explicitly disabled.
+**Prevention:** Always include `allowedMentions: { parse: [] }` in Discord message payloads sent by bots or integrations when transmitting untrusted log data.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Winston Discord transport did not explicitly disable Discord's mention parsing (`allowedMentions`). This meant that if an attacker could inject text like `@everyone` or `@here` into the application's logs, the Discord transport would transmit those tags, causing unwanted notification pings to all channel users. This creates a risk for log injection leading to Denial of Service (DoS) or harassment.
🎯 **Impact:** Malicious actors could weaponize error logs or user input tracking to constantly ping server members, rendering the logging channel unusable.
🔧 **Fix:** Refactored the `send()` call payload to explicitly include `allowedMentions: { parse: [] }`. This instructs Discord to render mention syntax as plain text without triggering notification pings. Updated relevant unit tests.
✅ **Verification:** Verified locally by running `npm run lint` and `npm run test` (via Vitest). All tests pass, and coverage checks succeed.

---
*PR created automatically by Jules for task [15088519175388736717](https://jules.google.com/task/15088519175388736717) started by @robertsmieja*