### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix uncontrolled discord mentions (log injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Log Injection via Discord Mentions
+**Vulnerability:** User-controlled log data sent to the Discord transport can contain `@everyone`, `@here`, or specific role/user IDs. Without explicit restrictions, the Discord API parses these tags and sends notifications to users, leading to unintended pings or malicious log injection attacks (abuse of logging infrastructure for unauthorized notification blasts).
+**Learning:** By default, discord.js will parse mentions if they are present in a message's content. A transport layer that faithfully logs arbitrary user data must explicitly disable mention parsing at the boundary to prevent attackers from sending pings through log messages.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in the `MessageOptions` payload when sending any form of message (including arrays with embeds) through the Discord API transport to disable all mention resolutions globally.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-controlled log data sent to the Discord transport could contain `@everyone`, `@here`, or specific role/user IDs. Without explicit restrictions, the Discord API parses these tags and sends notifications to users, leading to unintended pings or malicious log injection attacks (abuse of logging infrastructure for unauthorized notification blasts).
🎯 Impact: Attackers could abuse the logging infrastructure to send unauthorized notification blasts to all members of a Discord server where logs are sent.
🔧 Fix: Explicitly added `allowedMentions: { parse: [] }` to the `MessageOptions` payload when sending any form of message (including arrays with embeds) through the Discord API transport to disable all mention resolutions globally.
✅ Verification: Ran `npm run typecheck`, `npm run lint`, and `npm run test` successfully with updated `mockSend` expectations in `src/tests/DiscordTransport.test.ts` to include `allowedMentions: { parse: [] }`. Added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8232836772594576908](https://jules.google.com/task/8232836772594576908) started by @robertsmieja*