### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unrestricted discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection Unrestricted Discord Mentions
+**Vulnerability:** The Discord transport failed to disable mention parsing, meaning if user-controlled log data (e.g. usernames, input fields) contained `@everyone`, `@here`, or user/role mentions, Discord would actively ping those users when the log message was sent.
+**Learning:** External transports that support rich text or mentions (like Slack or Discord) can be weaponized for notification spam ("ping attacks") via log injection if mention parsing isn't explicitly disabled at the transport boundary.
+**Prevention:** Always set explicit mention suppression options (e.g. `allowedMentions: { parse: [] }`) when sending log data containing arbitrary external inputs to rich-text chat services.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Discord transport failed to disable mention parsing, meaning if user-controlled log data (e.g. usernames, input fields) contained `@everyone`, `@here`, or user/role mentions, Discord would actively ping those users when the log message was sent.
🎯 Impact: External transports that support rich text or mentions (like Slack or Discord) can be weaponized for notification spam ("ping attacks") via log injection if mention parsing isn't explicitly disabled at the transport boundary.
🔧 Fix: Add explicit mention suppression options (`allowedMentions: { parse: [] }`) when sending log data containing arbitrary external inputs to rich-text chat services. Update unit tests to expect the updated message payload format. Document this in the Sentinel journal.
✅ Verification: Ran `npm run test`, `npm run typecheck`, and `npm run lint` and all successfully passed without error.

---
*PR created automatically by Jules for task [3572719971580232388](https://jules.google.com/task/3572719971580232388) started by @robertsmieja*