### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix log injection allowing unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-04-26 - Prevent Unintended Mentions via Log Injection
+**Vulnerability:** Discord transport was forwarding raw log content directly to channels, allowing maliciously crafted log messages containing strings like `@everyone`, `@here`, or `<@USER_ID>` to trigger unauthorized mentions (pinging users/roles) because Discord automatically parses mentions by default.
+**Learning:** Log messages are often composed of user-controlled input. If the logging destination is a Discord channel, any input reflecting mention syntax will function as a real mention unless explicitly disabled by the transport.
+**Prevention:** Always include `allowedMentions: { parse: [] }` in the payload options for `discordChannel.send()` to strictly instruct the Discord API not to parse any @-mentions contained within the message content or embeds.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Sentinel: Prevent accidental mentions from log injection
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Sentinel: Prevent accidental mentions from log injection
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Log payloads are constructed dynamically from inputs and sent directly to Discord. Because Discord natively parses strings that resemble mentions (like `@everyone`, `<@USER_ID>`, or `@here`), a malicious actor injecting these strings into logs could trigger unauthorized mass notifications or targeted pings, enabling "Log Injection" abuse.
🎯 **Impact:** An attacker could abuse the application logging capabilities to continuously ping users, roles, or the entire server (`@everyone`), causing severe disruption, harassment, or a Denial of Service (DoS) for the moderation team.
🔧 **Fix:** Explicitly configured the Discord.js transport payload with `allowedMentions: { parse: [] }`. This acts as a strict defense-in-depth measure, cleanly instructing the Discord API not to parse any @-mentions contained within the message content or embeds originating from logs.
✅ **Verification:** Verified by updating Vitest integration tests to expect the new `allowedMentions` attribute on the discord.js object payload. All tests pass and ensure no regressions. The change spans only a few lines and leverages native Discord API functionality without pulling in heavy sanitization packages.

---
*PR created automatically by Jules for task [1403059761540154581](https://jules.google.com/task/1403059761540154581) started by @robertsmieja*