### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unrestricted mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-04-27 - [Log Injection & Unrestricted Mentions in Discord Transports]
+**Vulnerability:** The application was passing plain string messages to `this.discordChannel.send()` inside the logging transport module. This allowed any un-sanitized log input (e.g. usernames or debug values containing `@everyone` or `@here`) to silently "ping" and notify all users in the attached Discord channel.
+**Learning:** In logging integrations like Discord transports, we often forget that the output destination renders and executes markdown or special mention tags natively. What is simply text in a standard file logger becomes an executable command in chat APIs.
+**Prevention:** Always enforce strict boundaries at the transport layer for chat APIs. For `discord.js`, universally pass `{ content: logMessage, allowedMentions: { parse: [] } }` to completely disable server-wide, role, or user pings for all log output unless specifically and deliberately authorized.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The logger transport was piping messages as plain strings to Discord. If un-sanitized logged data (such as user input, errors, or custom log formats) happened to contain `@everyone`, `@here`, or specific role IDs, the bot would unintentionally ping and notify users across the server. This constitutes a "log injection" vulnerability that can be used maliciously for spam or notification fatigue.

🎯 **Impact:**
An attacker or misbehaving system could inject `@everyone` tags into user fields (like names or error outputs) that are logged to a Discord channel. The bot would then ping everyone in that channel, leading to harassment or DoS of attention.

🔧 **Fix:**
Modified `src/DiscordTransport.ts` to explicitly set `allowedMentions: { parse: [] }` on all `.send()` payloads. Plain string messages are now sent within a structured object payload, neutralizing all role and user mentions at the final transport boundary.

✅ **Verification:**
Updated all relevant assertions within `src/tests/DiscordTransport.test.ts` to explicitly check that `allowedMentions: { parse: [] }` is included. Tested via `npm run test` (51 tests passed) and typed check (`npm run typecheck`).

---
*PR created automatically by Jules for task [15334359020688580729](https://jules.google.com/task/15334359020688580729) started by @robertsmieja*