### PR TITLE
🛡️ Sentinel: [Medium] Fix log injection vulnerability via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Log messages constructed from external inputs were sent to Discord without restricting mention parsing (`@everyone`, `@here`, `@user`, etc.). This allowed attackers to inject mentions into log data, causing the Discord client to notify users or groups unintentionally (Log Injection / Mention Abuse).
+**Learning:** External transports like Discord that parse special syntax (like mentions) by default will execute that syntax even if it originates from log payloads.
+**Prevention:** Always explicitly disable mention parsing by setting `allowedMentions: { parse: [] }` on messages sent to Discord. Simple strings must be refactored to object payloads `{ content: '...', allowedMentions: { parse: [] } }` to enforce this.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** Log messages constructed from arbitrary or unvalidated inputs were being sent to Discord without restricting how Discord interprets mentions. Because Discord's API parses mentions (like `@everyone`, `@here`, or user IDs) by default, an attacker who controls log data could intentionally embed these tags, causing the Discord client to notify groups unintentionally. This is known as "Log Injection" leading to "Mention Abuse".

🎯 **Impact:** If an attacker sends malicious data containing Discord tags, those tags would be logged and sent to the associated Discord server where they would successfully ping `@everyone`, spamming channel members and enabling disruptive abuse of the monitoring infrastructure.

🔧 **Fix:** Refactored `this.discordChannel.send()` payloads in `src/DiscordTransport.ts` to universally include `allowedMentions: { parse: [] }`. Specifically, simple string logs were converted to `{ content: logMessage, allowedMentions: { parse: [] } }` payloads. This configuration explicitly instructs Discord to ignore all potential mentions in the content. Additionally, updated `src/tests/DiscordTransport.test.ts` to expect the new payload structures.

✅ **Verification:**
1. Ran `npm run test` and `npm run typecheck` to confirm all 51 tests successfully assert against the new securely-configured payloads. 
2. Ran `npm run lint` and `npm run lint:fix` to guarantee structural code compliance.
3. Created a record of this learning in `.jules/sentinel.md` to prevent future regression.

---
*PR created automatically by Jules for task [17522715512643260862](https://jules.google.com/task/17522715512643260862) started by @robertsmieja*