### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+## 2024-04-29 - Prevent Discord Log Injection Mention Attacks
+**Vulnerability:** Log payloads being sent to Discord did not enforce mention parsing rules (`allowedMentions: { parse: [] }`). Malicious actors could inject payloads containing `@everyone` or `@here` to ping server members arbitrarily via the logger.
+**Learning:** External transport targets like Discord can evaluate simple text string logging as interactive commands if no metadata restricts them.
+**Prevention:** Always wrap transport outputs to interactive platforms like Discord into fully configured payload objects rather than naked strings, explicitly disabling user pings globally (`allowedMentions: { parse: [] }`) at the final send boundary.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -56,12 +56,18 @@ export class DiscordTransport extends TransportStream {
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
+          // Security: Prevent log injection and unrestricted Discord mentions
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Security: Prevent log injection and unrestricted Discord mentions
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Log payloads being sent directly to Discord via `channel.send()` using bare strings (or incomplete payloads) failed to specify mention parsing rules. This allowed malicious actors to construct log messages containing `@everyone` or `@here`, which Discord would parse and evaluate as interactive commands, indiscriminately pinging server members.

🎯 **Impact:** If exploited, attackers could use the logging infrastructure to spam notifications and launch a denial-of-attention attack on server members via unauthorized `@everyone` and `@here` mentions.

🔧 **Fix:** Refactored the bare string payload in `src/DiscordTransport.ts` into a structured message object, and explicitly set `allowedMentions: { parse: [] }` on both branches (simple string and embeds). This guarantees that user pings and group mentions are strictly disabled at the transport boundary before being sent to Discord's API. 

✅ **Verification:** Ran `npm run test`, `npm run lint`, and `npm run typecheck` successfully. Updated unit tests to expect the explicit object payloads rather than plain strings.

---
*PR created automatically by Jules for task [4632558814683323553](https://jules.google.com/task/4632558814683323553) started by @robertsmieja*