### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-17 - [Log Injection Unrestricted Mentions]
+**Vulnerability:** Discord bot sending log messages without explicit mention parsing restrictions allows user-controlled logs to trigger unrestricted mentions (@everyone, @here, roles, users) leading to ping spam.
+**Learning:** `discord.js` by default will parse and resolve mentions in any text content passed to `.send()`, meaning plain strings containing mentions will actively ping users unless restricted.
+**Prevention:** Always refactor simple `.send(string)` calls into structured object payloads and explicitly set `allowedMentions: { parse: [] }` on all Discord transport boundaries.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] }
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] }
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection Unrestricted Mentions. `discord.js` by default will parse and resolve mentions in any text content passed to `.send()`. This meant that plain strings containing mentions (like `@everyone`, `@here`, `<@userId>`) in log messages would actively ping users unless restricted.
🎯 **Impact:** Malicious actors could inject mentions into standard log output to trigger unbounded ping spam (Denial of Service/Spam) via the Discord bot. 
🔧 **Fix:** Refactored the `send(logMessage)` calls into strict object payloads: `{ content: logMessage, allowedMentions: { parse: [] } }` across all paths (both simple string logs and embed logs). This forces Discord to render mentions as plain text without triggering ping notifications.
✅ **Verification:** Verified by running the vitest test suite. Test coverage (96.82%) is fully maintained. All 51 tests pass.

---
*PR created automatically by Jules for task [7465524993368581211](https://jules.google.com/task/7465524993368581211) started by @robertsmieja*