### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection and unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection & Unrestricted Mentions in Discord Transport
+**Vulnerability:** The Discord transport was passing raw log strings directly to the Discord API `send()` method without restricting mentions. An attacker could inject `@everyone`, `@here`, or specific user IDs into log messages (log injection), causing unintended mass pings and notification spam.
+**Learning:** External transports (like Discord or Slack) that support dynamic mention parsing must always have those features explicitly disabled when sending automated logs. User-supplied data must never be allowed to trigger alert mechanisms natively provided by the platform.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or the platform-equivalent setting) in message payload options to prevent dynamic mentions from being parsed by the transport API.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Discord transport previously passed arbitrary strings (including embedded structures) directly to the Discord API's `send()` method without restricting mention parsing. This allowed malicious payloads in logs to trigger mass pings or targeted user notifications (log injection).
🎯 Impact: Attackers could inject strings like `@everyone`, `@here`, or `<@user_id>` into system logs, weaponizing the bot integration to spam notifications and potentially bypass application-level notification logic.
🔧 Fix: Added `allowedMentions: { parse: [] }` to the message payload configuration options in `src/DiscordTransport.ts` to strictly disable all dynamic mention parsing.
✅ Verification: `npm run test`, `npm run typecheck`, and `npm run lint` were executed. All tests pass, and unit tests specifically checking the `mockSend` arguments were updated to enforce the explicit presence of the new `allowedMentions` attribute.

---
*PR created automatically by Jules for task [2186325010040729857](https://jules.google.com/task/2186325010040729857) started by @robertsmieja*