### PR TITLE
🛡️ Sentinel: High Fix unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-05-03 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** Discord's default behavior allows any `content` string to parse and trigger user/role mentions (e.g., `@everyone`, `<@123456>`). If an application logged arbitrary user input without sanitization, an attacker could trigger "Log Injection" that results in unrestricted Discord notifications, spamming server members.
+**Learning:** Whenever you send dynamic text/log content to a messaging platform (like Discord, Slack, etc.) that parses mentions, you must explicitly disable mention parsing at the transport boundary to prevent notification spam via malicious payloads.
+**Prevention:** Always include `allowedMentions: { parse: [] }` (or the platform-specific equivalent) in the `send()` options for both simple string messages and complex embed payloads.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
**🚨 Severity:** HIGH

**💡 Vulnerability:** Unrestricted Discord Mentions via Log Injection. Discord's API allows dynamic text within the `content` field to parse and trigger user/role mentions by default. If arbitrary, unsanitized user inputs are logged, an attacker could inject mentions resulting in "Log Injection" spam.

**🎯 Impact:** A malicious user could force the application's bot/integration to mass-ping `@everyone` or other roles/users in the connected logging channels, causing notification spam and potential reputational damage.

**🔧 Fix:** Added `allowedMentions: { parse: [] }` to the message payload in `this.discordChannel.send()` to strictly disable mention parsing at the transport boundary for all log messages.

**✅ Verification:** Ran `npm run test` and `npm run typecheck` successfully to ensure no regression and that the mocked Discord send functions correctly assert the presence of `allowedMentions: { parse: [] }`. Added a new critical learning journal entry.

---
*PR created automatically by Jules for task [5600405262952668665](https://jules.google.com/task/5600405262952668665) started by @robertsmieja*