### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Unrestricted Mentions via Log Injection
+**Vulnerability:** Discord integration allowed log payloads to trigger `@here`, `@everyone`, or user/role mentions if those text strings appeared in the log content. An attacker could exploit this by injecting mention strings into application inputs that are subsequently logged, leading to notification spam and "Ping Abuse."
+**Learning:** Sending unsanitized log content directly to chat platforms like Discord can lead to unintended side-effects beyond just displaying text, specifically unwanted notifications.
+**Prevention:** Always restrict parsing of mentions in chat platform integrations. For Discord, explicitly set `allowedMentions: { parse: [] }` in the message payload to ensure all content is treated as raw text and prevents triggering actual mentions.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Discord integration allowed log payloads to trigger `@here`, `@everyone`, or user/role mentions if those text strings appeared in the log content. An attacker could exploit this by injecting mention strings into application inputs that are subsequently logged, leading to notification spam and 'Ping Abuse'.
🎯 Impact: Notification spam and Ping Abuse across any channel connected to the Winston Discord transport.
🔧 Fix: Updated the `DiscordTransport.ts` message payload options to include `allowedMentions: { parse: [] }`. This instructs the Discord API to parse all content as raw text, preventing actual pings.
✅ Verification: `npm run test` verified with updated expectations. The `tests/DiscordTransport.test.ts` cases were updated to reflect the new `allowedMentions` payload structure.

---
*PR created automatically by Jules for task [6160504756393603817](https://jules.google.com/task/6160504756393603817) started by @robertsmieja*