### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-24 - [Log Injection Mention Vulnerability]
+**Vulnerability:** A log injection vulnerability in the Discord transport module allowed maliciously crafted log messages to trigger unrestricted global mentions (e.g., `@everyone` or `@here`) in Discord channels.
+**Learning:** The default behavior of the discord.js `send()` method processes all standard mentions if no explicit restrictions are defined. Without formatting protections on log contents, the logging library inadvertently became an attack vector for Denial of Service and harassment through spam mentions.
+**Prevention:** Always encapsulate plain text log strings into the payload object format (`{ content: logMessage }`) and explicitly restrict parsing capabilities by enforcing `allowedMentions: { parse: [] }` on every outgoing message across all execution paths.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Sentinel: Prevent log injection by disabling all explicit mentions (@everyone, @here, @role)
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Sentinel: Prevent log injection by disabling all explicit mentions (@everyone, @here, @role)
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection Mention Vulnerability. Maliciously crafted log messages (if containing untrusted user input) could exploit the default behavior of Discord's `.send()` method to trigger unrestricted global mentions (e.g., `@everyone`, `@here`, or specific `@role` IDs) within Discord channels.
🎯 **Impact:** If exploited, this could lead to harassment, spam, and Denial of Service (DoS) for users in the Discord server receiving the logs, severely degrading trust in the logging bot.
🔧 **Fix:** Refactored the `discordChannel.send()` calls in `src/DiscordTransport.ts` to encapsulate all log payloads into an object format. Explicitly applied `allowedMentions: { parse: [] }` to all outgoing messages (both standard messages and embed messages) to strictly disable the parsing of all types of explicit mentions.
✅ **Verification:** Verified by updating and passing the test suite in `src/tests/DiscordTransport.test.ts`, confirming the correct `{ content, allowedMentions }` payload structure is sent to Discord.

---
*PR created automatically by Jules for task [5968499556758641993](https://jules.google.com/task/5968499556758641993) started by @robertsmieja*