### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-13 - Unrestricted Discord Mentions in Logging Transport
+**Vulnerability:** The Discord logging transport was vulnerable to log injection triggering unintended `@everyone`, `@here`, or specific role/user mentions. If an application logged unfiltered user input containing these mention strings, the Discord bot would alert users.
+**Learning:** The vulnerability existed because the discord.js `send()` method defaults to parsing mentions within the message content if `allowedMentions` is not explicitly restricted.
+**Prevention:** Always restrict mention parsing by default when using discord.js to send logs or user-generated content. Set `allowedMentions: { parse: [] }` in the message payload options to ensure mentions are rendered as plain text without triggering notifications.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Security: Prevent log injection from triggering mentions
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Security: Prevent log injection from triggering mentions
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unrestricted Discord mention parsing in logging. By default, `discord.js` parses mentions like `@everyone`, `@here`, or specific user/role mentions in message content. If unvalidated user input were logged via this transport, an attacker could trigger a log injection attack causing unintended notifications.
🎯 **Impact**: The bot would ping users in Discord whenever a logged message containing mention strings is processed, creating noise and potentially allowing attackers to exploit the bot's permission scope to ping roles.
🔧 **Fix**: Added `allowedMentions: { parse: [] }` to the Discord API message payloads for both plain string messages and embed objects to strictly enforce that all content is treated as plain text and not parsed for mentions.
✅ **Verification**: Run `npm run test` to verify the `DiscordTransport.test.ts` suite passes with the updated `allowedMentions` mock assertions.

---
*PR created automatically by Jules for task [17965545123535478812](https://jules.google.com/task/17965545123535478812) started by @robertsmieja*