### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection via Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-14 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Simple string logs were sent directly to the Discord API without disabling mentions. Malicious input inside log messages (like `@everyone` or `<@userid>`) would be actively parsed and pinged by Discord, leading to notification spam and potential social engineering.
+**Learning:** External transports like Discord actively parse payload text for mentions by default. Sending unstructured string logs directly opens a vector for "Log Injection", where users can weaponize the logging system's output to mass-ping roles or users.
+**Prevention:** All messages sent via the Discord transport must explicitly set `allowedMentions: { parse: [] }` in the payload options. Refactor simple string content into an object payload `{ content: logMessage, allowedMentions: { parse: [] } }` to enforce this restriction safely across all logging paths.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unrestricted mentions in logging output sent directly to the Discord API. By default, Discord actively parses and notifies any mentions (e.g., `@everyone`, `<@userid>`) present in text content. If user-generated or unsanitized external strings are logged, it creates a "Log Injection" vector allowing bad actors to mass-ping roles or users, leading to notification spam and potential social engineering.
🎯 **Impact:** Malicious users could weaponize the logging system's output.
🔧 **Fix:** Refactored standard `string` payloads to use an object payload setting `allowedMentions: { parse: [] }`. Added `allowedMentions: { parse: [] }` explicitly to all `discordChannel.send()` calls across all execution paths. This ensures the Discord API does not parse or ping any `@` mentions present in the message content.
✅ **Verification:**
1. Tests updated to enforce the presence of `allowedMentions` config.
2. Verified changes pass tests with `npm run test` and `npm run lint`.

---
*PR created automatically by Jules for task [4066832407460860679](https://jules.google.com/task/4066832407460860679) started by @robertsmieja*