### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection via Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The Discord transport previously sent simple string logs directly to Discord or as a payload without `allowedMentions` configured. This could allow an attacker to inject special strings like `@everyone` or `@here` into logs (e.g. through a maliciously crafted username or error message), causing unauthorized mentions that disrupt operations or social engineer Discord users.
+**Learning:** Sending arbitrary text to chat APIs (like Discord or Slack) requires explicit configurations to disable the parsing of mentions (like tags or `@everyone`) to avoid "Log Injection" vulnerabilities.
+**Prevention:** Always encapsulate chat payloads inside objects and enforce strict mention parsing boundaries (e.g., `allowedMentions: { parse: [] }`) at the lowest transport level before sending the payload.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -56,12 +56,18 @@ export class DiscordTransport extends TransportStream {
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
+          // Security: Prevent unrestricted Discord mentions (e.g. @everyone) from log injection
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Security: Prevent unrestricted Discord mentions (e.g. @everyone) from log injection
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Discord transport previously sent string logs directly to Discord as simple text or within payloads without explicitly configuring `allowedMentions`. This could allow an attacker to inject special tags like `@everyone` or `@here` into logs (e.g., through maliciously crafted input such as a username, user agent, or error message).
🎯 **Impact:** If exploited, an attacker could trigger unauthorized mentions to disrupt server operations, ping `@everyone`, or social engineer other Discord users in the target server.
🔧 **Fix:** Explicitly set `allowedMentions: { parse: [] }` in the object payload before passing it to `discordChannel.send()` to prevent any string content in logs from being parsed as a Discord mention.
✅ **Verification:** Updated all relevant tests to expect `allowedMentions: { parse: [] }` in the test suite and ensured tests pass successfully with `npm run test` and `npm run lint:fix`.

---
*PR created automatically by Jules for task [14100812412087290148](https://jules.google.com/task/14100812412087290148) started by @robertsmieja*