### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection via Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-20 - Log Injection via Discord Mentions
+**Vulnerability:** Sending raw log messages to Discord via the `send()` API without explicitly disabling mentions allows attackers to inject `everyone` or `here` pings, or ping arbitrary roles/users if user input is reflected in the logs.
+**Learning:** External messaging APIs often evaluate mention syntax by default. When forwarding logs to chat applications (Discord, Slack, etc.), always explicitly disable mention parsing at the transport boundary to prevent log injection from becoming a notification spam vector.
+**Prevention:** In discord.js v13+, explicitly set `allowedMentions: { parse: [] }` on all message payloads sent by the logger.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Log Injection via Discord Mentions. Sending raw log messages to Discord via the `send()` API without explicitly disabling mentions allows attackers to inject `everyone` or `here` pings, or ping arbitrary roles/users if user input is reflected in the logs.
🎯 **Impact**: Attackers can use the logging application to send disruptive pings to the Discord server, effectively using log forwarding as a notification spam and abuse vector.
🔧 **Fix**: Enforced `allowedMentions: { parse: [] }` on all log message payloads sent via `discordChannel.send()` to prevent any unintended mention resolution.
✅ **Verification**: Run `npm run test` to verify the payload updates in `src/tests/DiscordTransport.test.ts`.

Recorded the pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17044536012965425806](https://jules.google.com/task/17044536012965425806) started by @robertsmieja*