### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection / unauthorized mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection / Unauthorized Mentions
+**Vulnerability:** Discord logging integration did not restrict Discord API from parsing mentions (e.g. `@everyone`, `@here`, `@user_id`) in log messages. This allowed attackers to craft malicious input that, when logged, would trigger unauthorized pings and notifications to users in the Discord server, functioning as a log injection vector.
+**Learning:** External notification or chat integrations (like Discord, Slack) must always explicitly disable unescaped user mentions in their message payload configurations unless intentionally designed to ping users.
+**Prevention:** Always set explicit `allowedMentions: { parse: [] }` (or the equivalent payload setting for the specific API) in the transport boundaries to disable automatic parsing of mentions in strings being logged.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The Discord transport logged arbitrary user content without restricting the `allowedMentions` payload property. Because Discord's API automatically parses unescaped mentions (e.g. `@everyone`, `@here`, `@12345`), an attacker could trigger a log injection attack by providing malicious strings that result in unauthorized pings and notifications across the Discord server. 
🎯 **Impact**: Allowed log spoofing and mass harassment through server notifications (log injection).
🔧 **Fix**: Added explicit `allowedMentions: { parse: [] }` to all message configurations inside `DiscordTransport.ts` to neutralize unescaped mention strings from being processed as pings by the Discord API. Tests were also updated to mirror this structure.
✅ **Verification**: Run `npm run test` to verify the payload structures are properly updated in unit tests.

---
*PR created automatically by Jules for task [4775335646991012306](https://jules.google.com/task/4775335646991012306) started by @robertsmieja*