### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Log messages were sent to Discord channels without restricting mentions. A maliciously constructed log message containing strings like "@everyone", "@here", or user/role IDs could unintendedly trigger notifications/mentions inside the Discord server where logs are routed. This creates a noisy abuse vector or potential social engineering risk.
+**Learning:** External integrations that parse rich text formats or specific mention syntaxes (like Discord's `<@user>` or `@everyone`) must strictly sanitize or disable those features at the transport layer to prevent "log injection" attacks.
+**Prevention:** Always set explicit mention restriction parameters (e.g., `allowedMentions: { parse: [] }`) on Discord message payloads.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection via Unrestricted Discord Mentions. Unsanitized log message contents containing strings shaped like `@everyone`, `@here`, or User/Role IDs (`<@id>`) would trigger actual Discord pings in the channel where logs are sent. This exposes the logging channel to notification spam or social engineering (e.g., an attacker creating a username like "@everyone" causing the log server to mass-ping).
🎯 **Impact:** Abuse of the logging channel, notification spam, and potential social engineering of server administrators.
🔧 **Fix:** Explicitly appended `allowedMentions: { parse: [] }` to the `discordChannel.send()` configurations, forcing the Discord API to parse mentions strictly as raw text and preventing them from triggering push notifications.
✅ **Verification:** Run `npm run test` to verify the new message payloads, or observe Discord logging behavior; raw mention strings will appear in chat without highlighting or pinging.

---
*PR created automatically by Jules for task [2205880059985993476](https://jules.google.com/task/2205880059985993476) started by @robertsmieja*