### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection leading to unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-05-25 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Simple string logs were sent directly to the Discord API without setting the `allowedMentions` option. If a user was able to inject strings like `@everyone`, `@here`, or specific role/user IDs into the log data, the Discord bot would actually ping those users/roles when outputting the log message, causing a form of notification spam/abuse.
+**Learning:** External integrations that provide markdown/ping features (like Discord or Slack) must always explicitly disable those features for log transport payloads, as log data is effectively untrusted user input.
+**Prevention:** All messages sent via the Discord transport must explicitly set `allowedMentions: { parse: [] }` in the message options to prevent unrestricted mentions.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection leading to Unrestricted Mentions. The discord.js transport was passing log payloads directly to Discord without specifying `allowedMentions`. An attacker could exploit this by injecting literal `@everyone`, `@here`, or role pings into logs, essentially turning the bot's logging outputs into notification spam that abuses role pings.
🎯 **Impact:** Abuse of the Discord system, pinging all users or specific roles unintentionally and maliciously from the bot.
🔧 **Fix:** Refactored the simple string log payload to use an object wrapper (`{ content, allowedMentions }`) and explicitly set `allowedMentions: { parse: [] }` across all message payload options sent by `this.discordChannel.send`.
✅ **Verification:** Ran test suite (`npm run test`) to verify test payload assertions. Reviewed the code changes locally to ensure proper types were maintained via `npm run typecheck` and `npm run lint`.

---
*PR created automatically by Jules for task [12123879908131615253](https://jules.google.com/task/12123879908131615253) started by @robertsmieja*