### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unrestricted Discord mentions (Log Injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Unrestricted Discord Mentions (Log Injection)
+**Vulnerability:** The logging framework sent plain strings or payloads without `allowedMentions` configured. This allows an attacker who can control log inputs (e.g., via user agent or error messages) to trigger notification spam and ping any Discord user or role (e.g., `@everyone`).
+**Learning:** External API wrappers sending messages to messaging platforms must enforce mention constraints at the final output boundary to prevent log injection from escalating into notification spam or harassment.
+**Prevention:** Always restrict mentions when using the Discord API by explicitly setting `allowedMentions: { parse: [] }` on outgoing message payloads, including simple text strings.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Unrestricted Discord Mentions (Log Injection). The `DiscordTransport` was passing log messages directly into the discord.js client's `.send()` method without filtering or restricting Discord's mention parsing. This allows an attacker who can control log inputs (such as generating specific error messages or user-agent strings) to trigger notification spam and ping any Discord user or role (e.g., `@everyone`) in the connected logging channel.
🎯 **Impact**: Harassment, notification spam, and potential abuse of the logging bot's privileges in the Discord server, undermining the utility and security of the logging channel.
🔧 **Fix**: Modified `src/DiscordTransport.ts` to explicitly set `allowedMentions: { parse: [] }` in the `MessageOptions` object for `this.discordChannel.send()`, both for simple strings and complex payloads with embeds.
✅ **Verification**: Run `npm run test` to verify that unit tests expect the new `allowedMentions` constraints and ensure backwards compatibility. Ensure changes are verified manually with `npm run build` and `npm run lint`. Documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4250710512813944177](https://jules.google.com/task/4250710512813944177) started by @robertsmieja*