### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection via Unrestricted Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-27 - Discord Log Injection via Unrestricted Mentions
+**Vulnerability:** The logger was sending log messages to Discord directly without disabling mention parsing (`allowedMentions: { parse: [] }`). This means an attacker could craft log payloads containing `@everyone` or `<@userid>` that would trigger actual pings when rendered in the Discord channel, facilitating a "Log Injection" vulnerability that spams users.
+**Learning:** External sinks that parse rich text formats or mentions (like Discord or Slack) must have those features explicitly disabled when transmitting untrusted log data.
+**Prevention:** Always configure `allowedMentions: { parse: [] }` on Discord message payloads. For plain string logs, wrap the content in an object (`{ content: logMessage, allowedMentions: { parse: [] } }`) to enforce this constraint.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Prevent log injection/unrestricted mentions
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Prevent log injection/unrestricted mentions
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log Injection. The logger was sending log messages to Discord directly without disabling mention parsing (`allowedMentions: { parse: [] }`).
🎯 **Impact:** An attacker could craft inputs containing `@everyone`, `@here`, or `<@userid>` that would trigger actual notifications when rendered in the Discord channel, facilitating notification spam and "Log Injection" attacks.
🔧 **Fix:** Added `allowedMentions: { parse: [] }` to all message payloads sent to Discord. Transitioned string-based `send()` calls to object payloads.
✅ **Verification:** Verified by checking the updated test suite. Local builds, linting, and vitest coverage all pass. Journal appended.

---
*PR created automatically by Jules for task [17741554372708868511](https://jules.google.com/task/17741554372708868511) started by @robertsmieja*