### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Prevent log injection unrestricted mentions
+**Vulnerability:** Discord channel mentions (e.g. `@everyone`) were evaluated and parsed when standard log strings were sent.
+**Learning:** Sending a basic string or an object with text content via `channel.send(logMessage)` or `channel.send({ content })` defaults to parsing mentions. This can result in denial of service and alert fatigue from maliciously crafted user input logs triggering `@everyone` and `@here`.
+**Prevention:** Always supply the `allowedMentions: { parse: [] }` field as part of the discord message payload.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Prevent log injection causing unrestricted mentions
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Prevent log injection causing unrestricted mentions
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: 
When `discordChannel.send(logMessage)` or `discordChannel.send({ content })` are used without explicitly defining `allowedMentions`, the Discord API will evaluate and parse standard mentions, such as `@everyone`, `@here`, and `@roles`. Because this is a logging mechanism handling dynamic and user-provided inputs, a malicious actor or errant script can trigger these tags intentionally, resulting in a log injection vulnerability.

🎯 **Impact**:
If an attacker injects strings like `@everyone` or `@here` into log outputs, it results in unintended server-wide or channel-wide notifications. This spam behavior causes denial of service through alert fatigue and severely degrades the operational integrity of the server.

🔧 **Fix**:
Updated `DiscordTransport.ts` to explicitly provide `allowedMentions: { parse: [] }` in the Discord API message payload. This explicitly instructs Discord to disable parsing of all mentions in log messages.

✅ **Verification**:
Ran the unit tests (`npm run test`) and format/lint checks (`npm run lint:fix`) successfully, validating the new payload object schema structure. Code coverage remains at passing thresholds. Also recorded this finding in `.jules/sentinel.md` as required.

---
*PR created automatically by Jules for task [8249156203402720887](https://jules.google.com/task/8249156203402720887) started by @robertsmieja*