### PR TITLE
🛡️ Sentinel: [security improvement] Disable Discord Mentions in Logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Discord Mentions
+**Vulnerability:** The transport previously sent raw string content directly to Discord. Because Discord natively parses text mentions like `@everyone` or `<@userid>`, an attacker who could control logged content (like usernames or input strings) could create "Log Injection" attacks. The logs would trigger real notifications and ping arbitrary roles or users, which is a major security and annoyance risk.
+**Learning:** Whenever you forward text to a system that supports parseable mentions or macros (like Discord or Slack), you must explicitly disable the parsing of those features to ensure the message is treated strictly as plain text.
+**Prevention:** Always use `allowedMentions: { parse: [] }` (or the equivalent payload) when sending data from untrusted contexts to Discord APIs.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **What:** Added `allowedMentions: { parse: [] }` to the message payloads sent via the Discord.js client.
🎯 **Why:** To prevent a "Log Injection" vulnerability. Previously, raw string content passed to the logger would be sent directly to Discord. Because Discord natively parses text mentions like `@everyone`, `@here`, or `<@userid>`, an attacker who could control logged content could trigger unwanted notifications, causing a nuisance or masking other malicious activity.
📊 **Impact:** Improved security by ensuring log content is treated strictly as plain text, eliminating the risk of unverified pings.
🔬 **Measurement:** Updated existing unit tests to verify that `allowedMentions: { parse: [] }` is correctly included in the `send()` payload for both simple string logs and complex embedded payloads. Verified the changes by running the test suite locally (`npm run test`).

---
*PR created automatically by Jules for task [12976521631374050854](https://jules.google.com/task/12976521631374050854) started by @robertsmieja*