### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix log injection via discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+## 2025-02-12 - Log Injection via Discord Mentions
+**Vulnerability:** Unrestricted Discord mentions allowed log injection. The Winston transport failed to set `allowedMentions` in message payloads, meaning maliciously crafted log payloads with `@everyone` or `@here` could generate pings to all server members when sent by the bot.
+**Learning:** External integrations that use markup or ping systems need defensive measures against arbitrary string injection. In Discord's case, all bot messages should explicitely define who they are allowed to ping.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in message configurations sent to the Discord API to prevent logs from generating undesired mentions.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Unrestricted Discord mentions allowed log injection. The Winston transport failed to set `allowedMentions` in message payloads, meaning maliciously crafted log payloads with `@everyone` or `@here` could generate pings to all server members when sent by the bot.
🎯 **Impact**: If an application using this library logged un-sanitized user input, an attacker could trigger a global ping across the entire Discord server where the bot is connected, causing spam and abuse.
🔧 **Fix**: Modified `src/DiscordTransport.ts` to include `allowedMentions: { parse: [] }` in the message payload sent via `discordChannel.send`. This prevents any user inputs passed to the logger from causing unintended mentions. Updated all related tests in `src/tests/DiscordTransport.test.ts`. Also added a journal entry in `.jules/sentinel.md` documenting the vulnerability and solution.
✅ **Verification**: Verified using `npm run test` and `npm run lint`. All tests pass, and coverage checks satisfy requirements.

---
*PR created automatically by Jules for task [3346152391920747847](https://jules.google.com/task/3346152391920747847) started by @robertsmieja*