### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix log injection triggering unrestricted mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection Triggering Unrestricted Mentions
+**Vulnerability:** Sending string log messages or embeds without restricting allowed mentions allows attackers who can inject content into log messages to trigger unexpected user, role, or \@everyone mentions in the Discord channel.
+**Learning:** Any logging transport mapping logs to a platform with pinging functionality (like Discord or Slack) must always explicitly disable or strictly restrict mention parsing on outbound messages.
+**Prevention:** In Discord.js integrations, always set `allowedMentions: { parse: [] }` in the payload (converting plain strings to an object payload if necessary) when sending unsanitized data like application logs.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unrestricted mentions via log injection. When sending string log messages or embeds without restricting allowed mentions, attackers who can inject content into logs (e.g., via user input reflected in application logs) could trigger unexpected user, role, or `@everyone` mentions in the Discord channel.
🎯 **Impact:** Attackers could abuse the logging channel to constantly ping administrators, roles, or all users in a server, leading to disruption, annoyance, and alert fatigue (a form of social engineering or Denial of Service via notifications).
🔧 **Fix:** Refactored the `discordChannel.send()` calls in `src/DiscordTransport.ts` to explicitly set `allowedMentions: { parse: [] }`. For simple string logs, this involved converting the payload to an object format (`{ content, allowedMentions }`).
✅ **Verification:** Verified that `npm run test` passes (which confirms that the `send` method mock tests now correctly assert the `allowedMentions` property is included) and that `npm run lint` and `npm run typecheck` run without errors.

---
*PR created automatically by Jules for task [12678581533111908359](https://jules.google.com/task/12678581533111908359) started by @robertsmieja*