### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions (Log Injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The logger was sending log messages to Discord directly without restricting mentions. An attacker who controls data that gets logged (e.g., input names or error messages) could inject strings like `@everyone`, `@here`, or specific role/user IDs, causing the Discord bot to ping users maliciously.
+**Learning:** External sinks like Discord channels have side effects associated with certain payload structures (like parsing mentions by default). Failing to sanitize or restrict these side-effects allows standard data ingestion to become an attack vector.
+**Prevention:** Always restrict mention parsing (`allowedMentions: { parse: [] }`) when sending user-generated or dynamic data to Discord endpoints, regardless of whether it's a direct message or an embed payload.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Unrestricted Discord Mentions (Log Injection). The `DiscordTransport` logger forwarded log messages to Discord channels without explicitly setting `allowedMentions: { parse: [] }`.

🎯 **Impact:** Since Discord's default behavior allows `@everyone`, `@here`, and direct user/role mentions to be parsed and pinged, an attacker could potentially achieve "Log Injection." If any malicious user input or untrusted string gets logged (e.g., in a username, a requested URL path, or an error context), the attacker could force the Discord bot to mass-ping members on the receiving server, resulting in alert fatigue or a Denial of Service (DoS) of the moderation channel.

🔧 **Fix:** Refactored the `this.discordChannel.send()` calls to strictly use object payloads with `allowedMentions: { parse: [] }` passed in. This guarantees the Discord API will treat any `@` symbols in the log output as literal text and will not trigger a notification. Corresponding unit tests were updated to assert this exact structure.

✅ **Verification:**
1. Unit tests run locally using `npm run test` confirm the updated structure is passed correctly to `discord.js`.
2. Lint check `npm run lint` passes with no issues.
3. Codecov and CI checks should pass upon PR creation.

---
*PR created automatically by Jules for task [9659418175416558894](https://jules.google.com/task/9659418175416558894) started by @robertsmieja*