### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix log injection mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2026-06-04 - [Preventing log injection in Discord messages]
+**Vulnerability:** Log payloads are susceptible to unintended log injection mentioning users and roles in Discord messages if a log entry contains strings resolving to discord user or role ids.
+**Learning:** The `send()` function in discord.js triggers mentions by default. Passing an explicit `{ content, allowedMentions: { parse: [] } }` blocks this feature entirely on the client, thereby neutralizing log injection capabilities.
+**Prevention:** Ensure `allowedMentions: { parse: [] }` is set in the options object sent to `discordChannel.send()` for any logging payloads.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Security: Prevent log injection mentions
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Security: Prevent log injection mentions
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Log payloads are susceptible to unintended log injection mentioning users and roles in Discord messages if a log entry contains strings resolving to discord user or role ids. By default, the discord.js `send()` method parses mentions.
🎯 Impact: Attackers could inject arbitrary log messages containing `<@123456789>` to bypass logging mechanisms and aggressively ping arbitrary users or `@everyone` if the bot has those permissions.
🔧 Fix: Updated the `logMessage` payload sent to `discordChannel.send()` to explicitly include `allowedMentions: { parse: [] }`. This prevents the client from parsing mentions at the source before they even hit the API, neutralizing the vulnerability completely. Tests were updated to accommodate the new object schema.
✅ Verification: Ran `npm run test` and `npm run lint`. All tests passed. Confirmed via `git diff`.

---
*PR created automatically by Jules for task [16017127688030027435](https://jules.google.com/task/16017127688030027435) started by @robertsmieja*