### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unrestricted Discord mentions (Log Injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Log messages sent to Discord were not restricting mentions. If an application logged arbitrary user input (like usernames or user-provided error strings), an attacker could inject mentions (e.g., @everyone or @here) that would be parsed and pinged by Discord, leading to notification spam and potential abuse.
+**Learning:** Any logging transport that relies on an external system with a rich parsing layer (like Discord's mention system) must explicitly disable that parsing layer by default for arbitrary text content to prevent unintended log injection.
+**Prevention:** Always explicitly set `allowedMentions: { parse: [] }` on payloads sent to the Discord API to ensure arbitrary text is never treated as a mention.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Log messages sent to Discord were not restricting mentions. If an application logged arbitrary user input (like usernames, error messages, or request bodies), an attacker could inject mentions (e.g., `@everyone` or `@here`) that would be parsed and pinged by Discord.
🎯 **Impact:** Attackers could trigger mass notification spam and potential abuse, leading to a log injection/mention spam attack.
🔧 **Fix:** Explicitly set `allowedMentions: { parse: [] }` on payloads sent to the Discord API via `discordChannel.send()` to ensure arbitrary text is never treated as a mention, effectively neutralizing the injection vector.
✅ **Verification:** Verified by updating unit tests to assert the new payload structure, and running `npm run check && npm run test` to ensure 100% test pass rates and no linting errors.

---
*PR created automatically by Jules for task [13054428147458452574](https://jules.google.com/task/13054428147458452574) started by @robertsmieja*