### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unhandled promise rejection in discordClient.login and missing allowedMentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Missing allowedMentions leading to Log Injection & Unhandled Promise Rejection DoS
+**Vulnerability:** Sending string log messages directly to Discord API without setting `allowedMentions: { parse: [] }` allows attackers who can inject string payloads into the logs to trigger arbitrary "@" mentions in the Discord channel. In addition, an unhandled Promise rejection on `discordClient.login()` would crash the Node.js application (DoS) if authentication failed.
+**Learning:** External transports like Discord must restrict potentially harmful dynamic side effects like mentions when relaying un-sanitized log strings. Furthermore, external async calls like authentication must always have a `.catch()` block to fail safely without bringing down the host application.
+**Prevention:** Always set explicit bounds and permissions on output bounds (e.g., passing `{ content: message, allowedMentions: { parse: [] } }` over a simple string). Ensure external Promises have a `.catch()` attached.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -33,7 +33,9 @@ export class DiscordTransport extends TransportStream {
           this.discordClient.on("error", (error) => {
             this.emit("warn", error)
           })
-          this.discordClient.login(discordToken)
+          this.discordClient.login(discordToken).catch((error) => {
+            this.emit("warn", error)
+          })
         }
       }
 
@@ -59,9 +61,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -4,7 +4,17 @@ import DiscordTransport, {
 } from "../DiscordTransport"
 import * as Discord from "discord.js"
 
-vi.mock("discord.js")
+vi.mock("discord.js", async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    Client: vi.fn(function () {
+      this.login = vi.fn(() => Promise.resolve("token"))
+      this.on = vi.fn()
+      this.destroy = vi.fn()
+    }),
+  }
+})
 
 describe("DiscordTransport", () => {
   describe("constructor", () => {
@@ -34,7 +44,7 @@ describe("DiscordTransport", () => {
       const fakeChannelManager = {} as Partial<Discord.ChannelManager>
 
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
       fakeDiscordClient.channels = fakeChannelManager as Discord.ChannelManager
@@ -47,9 +57,7 @@ describe("DiscordTransport", () => {
 
       const discordClient = transport.discordClient as typeof fakeDiscordClient
 
-      const mockedLogin = discordClient.login as MockedFunction<
-        (typeof Discord.Client)["prototype"]["login"]
-      >
+      const mockedLogin = discordClient.login as MockedFunction<any>
       const mockedOn = discordClient.on as MockedFunction<
         (typeof Discord.Client)["prototype"]["on"]
       >
@@ -67,7 +75,7 @@ describe("DiscordTransport", () => {
 
       // Recreate how discordClient is handled in the previous test
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
 
@@ -135,7 +143,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +166,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +188,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +217,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +241,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
1. **Unhandled Promise Rejection:** The `discordClient.login()` method is asynchronous and can reject if authentication fails (e.g., due to an invalid token or network error). This rejection was unhandled, leading to a complete crash of the Node.js application (Denial of Service).
2. **Log Injection (Unintentional Pings):** The `discordChannel.send()` method was invoked without explicit bounds on `allowedMentions`. This allowed any log message containing string inputs like `@everyone`, `@here`, or user/role pings to be parsed and evaluated by Discord, leading to unintended and potentially malicious spam/notifications.

🎯 **Impact:**
An attacker could intentionally cause the logging transport to crash the entire node application via the login rejection, or they could inject `@everyone` payloads into simple string logs, resulting in disruptive spam across a target server.

🔧 **Fix:**
- Added a `.catch()` block to `this.discordClient.login(...)` that delegates the error to the pre-existing `'warn'` emitter without crashing the process.
- Updated all `discordChannel.send(...)` payloads to include `{ allowedMentions: { parse: [] } }` ensuring any `@everyone`, `@here`, or User/Role mentions found within log strings are treated strictly as plain text.

✅ **Verification:**
Ran the test suite (`npm run test`) to ensure functionality and the changes to the transport do not break log delivery. Fixed the type definitions and assertions on the Discord mock client within `DiscordTransport.test.ts` to expect both `.catch()` logic and the `allowedMentions` payload properly. Ran linting (`npm run lint:fix`) to ensure formatting passes CI.

---
*PR created automatically by Jules for task [10513625919852711831](https://jules.google.com/task/10513625919852711831) started by @robertsmieja*