### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix log injection via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-13 - Log Injection via Discord Mentions
+**Vulnerability:** Discord allows pinging/mentioning users and roles like @everyone, @here, or specific user/role IDs if they are present in a message's content. The logging transport didn't restrict `allowedMentions`, which meant that any user-controlled input (e.g., a username or message) included in logs could trigger unintended notifications or annoyances in the logging channel.
+**Learning:** Sending unsanitized log content to chat platforms that parse mentions can lead to abuse, alert fatigue, or social engineering attacks if an attacker injects mentions in logged inputs.
+**Prevention:** Always disable parsing of mentions (e.g. `allowedMentions: { parse: [] }` in Discord) for automated notifications and logs to prevent input-driven pings.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Winston Discord transport passed string inputs directly to the Discord API without setting `allowedMentions`. This allowed any log messages containing string representations like `@everyone`, `@here`, or targeted role/user pings (e.g., `<@&role_id>`) to trigger actual notifications in Discord.
🎯 Impact: Attackers or malformed inputs could spam a channel, causing alert fatigue, social engineering risks, or general annoyance to users in the logging channel. 
🔧 Fix: Updated the message payload structure to use an object payload including `allowedMentions: { parse: [] }`. This instructs Discord to render the mentions as plain text without sending push notifications.
✅ Verification: Ran `npm run test` and `npm run lint` and all verified correctly with no regressions. Also updated unit tests to expect the `allowedMentions` object.

---
*PR created automatically by Jules for task [14649775974270296606](https://jules.google.com/task/14649775974270296606) started by @robertsmieja*