### PR TITLE
🛡️ Sentinel: [HIGH] Fix mention injection via unrestricted log payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Mention Injection via Unrestricted Log Payloads
+**Vulnerability:** Messages sent via the Discord transport layer used simple strings or omitted mention configurations, which allows user-controlled inputs embedded in logs to arbitrarily mention Discord users, roles, or "@everyone", enabling log injection spam attacks.
+**Learning:** External integrations like Discord will parse mention tags by default in any text content they receive. Logging systems must be strictly designed not to trigger mentions unless explicitly intended, to prevent "Mention Injection".
+**Prevention:** Always encapsulate messages sent to Discord inside a payload object and explicitly set `allowedMentions: { parse: [] }` to forcefully disable mention parsing across all content.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Unrestricted Mention Injection
The `winston-discordjs` transport layer previously sent strings or payload objects to the Discord API without configuring `allowedMentions`. Because Discord parses `@mentions` (such as `@everyone`, `@here`, or `@User`) by default, any user-controlled input (like HTTP request paths or error messages) that is logged could maliciously trigger a mention in the Discord channel.

🎯 **Impact:**
An attacker could inject `@everyone` or `@here` into error messages or payloads to cause severe mention spam and log injection attacks in the connected Discord channel, leading to potential social engineering or alert fatigue.

🔧 **Fix:**
Modified `src/DiscordTransport.ts` to convert all string-based payload sending mechanisms to explicitly defined object payloads and appended the strict setting `allowedMentions: { parse: [] }`. This forces Discord to never parse any tags as mentions, effectively neutralizing the attack vector. Tests in `src/tests/DiscordTransport.test.ts` were updated accordingly. A learning entry was also added to `.jules/sentinel.md`.

✅ **Verification:**
1. Ran `npm run lint:fix` to ensure code style compliance.
2. Ran `npm run test` ensuring all 51 tests passed, including updated expectations for the `Discord.TextChannel["send"]` mocked function.
3. Successfully built the project with `npm run build`.

---
*PR created automatically by Jules for task [5336261942500676479](https://jules.google.com/task/5336261942500676479) started by @robertsmieja*