### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection via Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-06-14 - Log Injection via Unrestricted Mentions
+**Vulnerability:** The transport directly sent log strings to Discord without setting `allowedMentions`. This allowed maliciously crafted log messages containing `<@user_id>` or `@everyone` to successfully ping Discord users, acting as a log injection vector to harass users.
+**Learning:** External communication APIs (like Discord) often parse text content for special control sequences (like mentions). Passing raw external log data directly to these APIs without disabling parsing features turns logging paths into an abuse vector.
+**Prevention:** When sending plain string content to APIs that support mentions, always wrap the content in an object payload and explicitly disable mention parsing (e.g., `allowedMentions: { parse: [] }`).

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The transport directly sent log strings to Discord without setting `allowedMentions`. This allowed maliciously crafted log messages containing `<@user_id>` or `@everyone` to successfully ping Discord users, acting as a log injection vector to harass users.
🎯 **Impact:** Attackers or external systems could inject Discord mentions into logs, causing widespread notifications, user harassment, and potentially exploiting logging systems for spam.
🔧 **Fix:** Refactored the `send()` call to explicitly send an object payload with `allowedMentions: { parse: [] }` to prevent Discord from parsing and triggering any `@` mentions within log contents. This enforcement applies to both simple strings and embedded logs.
✅ **Verification:** Verified by updating and running `src/tests/DiscordTransport.test.ts` to assert that `allowedMentions: { parse: [] }` is correctly included in the `mockSend` calls, and running `npm run lint:fix && npm run test` which executed successfully.

---
*PR created automatically by Jules for task [1032100274726502322](https://jules.google.com/task/1032100274726502322) started by @robertsmieja*