### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection Mentions Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestrained Mentions in Log Transport Payload
+**Vulnerability:** The Discord transport `send()` calls did not restrict mention parsing in log messages, allowing any arbitrary user input logged by the application to potentially trigger an unexpected and unrestricted mention ping in the target logging channel (Log Injection).
+**Learning:** Whenever transmitting external log data to a chat platform (like Discord, Slack), default behavior may parse strings as @mentions. To prevent mention spam from logged input, transports must explicitly disable mention parsing at the protocol level.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or equivalent) in log payload objects rather than just passing the raw string content.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -53,15 +53,21 @@ export class DiscordTransport extends TransportStream {
 
       if (this.discordChannel && logMessage) {
         let messagePromise: Promise<Message>
+        // Security: Explicitly disable mention parsing to prevent log injection
+        // where arbitrary user input could trigger @everyone or user pings.
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Log Injection leading to Unrestrained Mentions. The Discord transport previously passed arbitrary log strings directly into `discordChannel.send()` or as the `content` property without restricting mention parsing. This allowed any user input logged by the application to potentially trigger an unexpected and unrestricted mention ping (including `@everyone` or `@here`) in the target logging channel.

🎯 **Impact:** Malicious actors could intentionally construct payloads or usernames containing Discord mention syntax. When these inputs inevitably hit a logging path, they would execute as a mention in the Discord channel, leading to notification spam, abuse, and potential disruption to monitoring workflows.

🔧 **Fix:** Explicitly set `allowedMentions: { parse: [] }` on the Discord message payload to ensure that the Discord API completely ignores any mention syntax found within the log content, effectively neutralizing the log injection vulnerability at the protocol level.

✅ **Verification:** Unit tests have been explicitly updated to verify that the `mockSend` function requires the `allowedMentions` property in the options object. Running `npm run test` successfully executes the updated vitest test suite.

---
*PR created automatically by Jules for task [15383833873200179008](https://jules.google.com/task/15383833873200179008) started by @robertsmieja*