### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Logging via TypeErrors in Type Guards

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Denial of Logging via TypeErrors in Type Guards
+**Vulnerability:** The logging path contained a type guard `isTransformableInfo` that used the `in` operator on `info` cast to `any` (`"level" in (info as any)`) without explicitly checking if the parameter was an object or not null. This caused a runtime TypeError to crash the process when primitives (like strings or booleans) were passed.
+**Learning:** Type guards processing unknown or any variables, particularly in critical paths like logging, must be fully defensive and validate the type of the argument first (e.g., `typeof info === 'object' && info !== null`) before accessing its properties or using operators like `in`.
+**Prevention:** Always ensure type guards in logging pipelines defensively check input types to prevent Denial of Service via unhandled runtime exceptions.

--- a/src/LogHandlers.ts
+++ b/src/LogHandlers.ts
@@ -6,7 +6,12 @@ import { LogLevel, LogLevelToColor } from "./LogLevels"
 export const isTransformableInfo = (
   info: unknown
 ): info is TransformableInfo => {
-  return Boolean(info && "level" in (info as any) && "message" in (info as any))
+  return Boolean(
+    typeof info === "object" &&
+      info !== null &&
+      "level" in info &&
+      "message" in info
+  )
 }
 
 const sortFields = (fields: string[]): string[] => {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The logging framework type guard `isTransformableInfo` blindly cast an `unknown` variable `info` to `any` and used the `in` operator (`"level" in (info as any)`). JavaScript throws a `TypeError` if `in` is used on a primitive value. If an attacker injects or forces logging of simple primitive structures at an endpoint, this results in an unhandled exception.
🎯 **Impact:** If the transport throws unhandled exceptions during logging, the Node.js process crashes, leading to Application Denial of Service or "Denial of Logging" which silently disables monitoring systems while a real attack occurs.
🔧 **Fix:** Modified the type guard in `src/LogHandlers.ts` to implement full defensive checking: `typeof info === "object" && info !== null` prior to attempting property checks.
✅ **Verification:** A test payload of standard primitives (`isTransformableInfo('hello')` and `isTransformableInfo(true)`) runs smoothly instead of triggering TypeErrors. Verified via the CI suite executing `npm run test` successfully.

---
*PR created automatically by Jules for task [17142311330709636526](https://jules.google.com/task/17142311330709636526) started by @robertsmieja*