### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection / Unrestricted Mentions via Discord
+**Vulnerability:** The Winston Discord transport passed string logs directly to `discordChannel.send()` without restricting allowed mentions. A malicious user could craft a log message containing `@everyone`, `@here`, or `@User` and the bot would successfully ping those targets when the log was sent, leading to notification spam or social engineering (Unrestricted Mentions).
+**Learning:** Bots sending unstructured/untrusted text into Discord should never rely on Discord's default mention parsing settings.
+**Prevention:** Always explicitly set `allowedMentions: { parse: [] }` when sending messages using the Discord API unless mentions are explicitly required and tightly controlled.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Unrestricted Mentions (Log Injection)
The Winston Discord transport was passing string logs directly to `discordChannel.send()` without restricting allowed mentions. A malicious user or attacker could craft a payload (e.g., in user input that gets logged) containing `@everyone`, `@here`, or `@User` mentions. Because the bot uses its own permissions to send these logs, it would successfully ping those targets, leading to notification spam or potential social engineering (Log Injection resulting in unintended Mentions).

🎯 **Impact:**
An attacker could cause the bot to ping arbitrary users or roles in the server where logs are sent, abusing the bot's permissions. This can cause severe notification fatigue or be used to maliciously alert users.

🔧 **Fix:**
Modified `src/DiscordTransport.ts` to always include `allowedMentions: { parse: [] }` in the `discordChannel.send()` calls. This tells the Discord API to suppress all role/user/everyone mentions in the message content, regardless of what the log message string contains.

✅ **Verification:**
1. Confirmed `npm run lint:fix` passes.
2. Updated tests in `src/tests/DiscordTransport.test.ts` to expect `allowedMentions: { parse: [] }` in the `mockSend` calls.
3. Verified the test suite passes via `npm run test` against the updated payload structures.
4. Added critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5533515495701266135](https://jules.google.com/task/5533515495701266135) started by @robertsmieja*