### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions via Log Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-06-20 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** The Discord transport sent log messages without restricting parsed mentions, meaning an attacker could inject arbitrary `<@userid>`, `<@&roleid>`, or `@everyone` mentions into log fields to ping users/roles in the logging channel.
+**Learning:** Logging systems must never blindly trust formatted output when sending messages to platforms that automatically parse mentions.
+**Prevention:** Always explicitly set `allowedMentions: { parse: [] }` on outgoing Discord messages to prevent mention abuse via log injection.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -56,12 +56,18 @@ export class DiscordTransport extends TransportStream {
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
+          // Security: Prevent arbitrary mentions from being parsed via log injection
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Security: Prevent arbitrary mentions from being parsed via log injection
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unrestricted Discord Mentions via Log Injection. The Discord transport previously sent log messages without restricting parsed mentions. If user input or external data was logged and contained formatted mention strings (e.g., `<@userid>`, `<@&roleid>`, `@everyone`), Discord would parse them and ping the corresponding users/roles in the logging channel.
🎯 **Impact:** An attacker could craft malicious input to be logged (e.g., via HTTP headers, usernames, or error messages) containing mention strings, resulting in spam, harassment, or social engineering attacks against the administrators monitoring the logging channel.
🔧 **Fix:** Refactored `this.discordChannel.send` calls to explicitly enforce `allowedMentions: { parse: [] }`. Simple string logs are now wrapped in an object payload `{ content: logMessage, allowedMentions: { parse: [] } }` to ensure the API ignores all mentions.
✅ **Verification:** Verified by updating and running unit tests (`npm run test`) and ensuring `eslint` and `prettier` pass (`npm run lint:fix`). The changes effectively disable mention parsing across all outgoing messages.

---
*PR created automatically by Jules for task [13074538821914651696](https://jules.google.com/task/13074538821914651696) started by @robertsmieja*