### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The logging transport sent messages to Discord without restricting parsed mentions (`allowedMentions: { parse: [] }`), allowing malicious actors to inject `@everyone`, `@here`, or role pings into log fields.
+**Learning:** External integrations that parse text for mentions (like Discord or Slack) must always have those features explicitly disabled when transmitting untrusted log data, otherwise they become a vector for denial-of-attention or social engineering attacks.
+**Prevention:** Always explicitly set strict `allowedMentions` policies on outgoing message payloads containing log data.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Log injection via unrestricted mentions. The transport sent messages to Discord without restricting parsed mentions (`allowedMentions: { parse: [] }`).
🎯 Impact: Attackers or malformed log inputs could trigger `@everyone`, `@here`, or targeted role pings in the target Discord server by injecting them into the logged fields.
🔧 Fix: Enforced `allowedMentions: { parse: [] }` on both embed and raw string Discord outgoing payloads.
✅ Verification: Ran `npm run test` and `npm run lint:fix` and ensured all tests successfully pass with the updated mocked message payload structures.

---
*PR created automatically by Jules for task [6934600354508966845](https://jules.google.com/task/6934600354508966845) started by @robertsmieja*