### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix log injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-13 - Log Injection / Ping Abuse in Discord Transport
+**Vulnerability:** Application logs are transmitted directly to a Discord channel. When processing untrusted user input or application state, a malicious actor could intentionally craft payload strings containing Discord mention syntax (e.g., `@everyone`, `<@123456789>`). By default, Discord would parse these and send notifications to users, turning the logging framework into an involuntary spam/harassment vector.
+**Learning:** Logging systems hooked into chat applications (Discord, Slack) inherit the chat application's parsing behavior unless explicitly disabled.
+**Prevention:** Always sanitize messages or instruct the API to ignore mention parsing at the transport boundary by passing `allowedMentions: { parse: [] }` in the payload options.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] }, // 🛡️ Sentinel: Prevent log injection mentions
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] }, // 🛡️ Sentinel: Prevent log injection mentions
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Winston Discord transport did not restrict mention parsing when sending messages to Discord channels. A malicious user could intentionally inject Discord syntax (e.g., `@everyone`, `<@user_id>`) into application inputs that eventually get logged. 
🎯 Impact: Without parsing restrictions, Discord treats those log entries as active mentions, alerting the target users. This allows attackers to use the logging framework as an involuntary vector for spam or harassment.
🔧 Fix: Modified the `send` options in `src/DiscordTransport.ts` to include `allowedMentions: { parse: [] }`, instructing Discord to completely ignore all role and user mentions in the provided log payload string. Tests were also updated.
✅ Verification: Ran `npm run lint:fix` and `npm run test`, confirming all unit tests pass with the new object structure payload in the mocked Discord client behavior.

---
*PR created automatically by Jules for task [2870231289715713988](https://jules.google.com/task/2870231289715713988) started by @robertsmieja*