### PR TITLE
🛡️ Sentinel: [HIGH] Fix Log Injection via Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-06-24 - Log Injection via Discord Mentions
+**Vulnerability:** Discord's API parses mentions (like @everyone or @here) in messages by default. A maliciously crafted log message containing these strings could result in unintended pings to all users in a channel, acting as a nuisance or DoS mechanism.
+**Learning:** External sinks with complex formatting rules (like Discord) need explicit configuration to avoid treating log data as control characters or actionable commands.
+**Prevention:** Always set `allowedMentions: { parse: [] }` when sending data through the Discord API for logging purposes to ensure logs remain plain text and non-actionable.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -153,6 +156,7 @@ describe("DiscordTransport", () => {
       >
 
       expect(mockSend).toHaveBeenCalledWith({
+        allowedMentions: { parse: [] },
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
       })
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: Log Injection via Discord Mentions. Discord's API parses mentions in messages by default. A maliciously crafted log message containing these strings (like `@everyone` or `@here`) could result in unintended pings to all users in a channel.

🎯 Impact: This acts as a nuisance or DoS mechanism by pinging everyone in a channel when their input is logged.

🔧 Fix: Disabled parsing of mentions in log messages sent through the Discord transport by explicitly setting `allowedMentions: { parse: [] }` in the message options. This restriction applies to both simple strings and complex payloads. For simple string content, refactored the `send(logMessage)` call into an object payload: `{ content: logMessage, allowedMentions: { parse: [] } }`.

✅ Verification: Run `npm run test` to verify that the tests pass with the updated payload expectations. I have also verified this fix locally.

---
*PR created automatically by Jules for task [3971348984279498295](https://jules.google.com/task/3971348984279498295) started by @robertsmieja*