### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unrestricted Discord mentions in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-06-26 - Log Injection / Mention Abuse
+**Vulnerability:** The Winston Discord transport did not restrict Discord mentions when sending log messages. An attacker who can control log content (e.g., via user input) could inject `@everyone`, `@here`, or specific user/role mentions, causing "Ping Spam" or mention abuse.
+**Learning:** When sending automated messages to external platforms with mention capabilities, explicitly disable or restrict mentions to prevent abuse.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or similar restrictions) in the message payload when sending logs to Discord.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Winston Discord transport did not restrict Discord mentions when sending log messages. An attacker who can control log content (e.g., via user input) could inject `@everyone`, `@here`, or specific user/role mentions.
🎯 **Impact:** This vulnerability could lead to "Ping Spam" or mention abuse against servers or users where the bot has permission to mention them, allowing attackers to harass users via automated log pipelines.
🔧 **Fix:** Added `allowedMentions: { parse: [] }` to the message options in all `discordChannel.send()` calls within `DiscordTransport.ts` to explicitly instruct the Discord API to parse zero mentions from the string content.
✅ **Verification:** Updated all unit tests in `src/tests/DiscordTransport.test.ts` to explicitly assert the presence of `allowedMentions: { parse: [] }` in the payload passed to the mocked Discord `send` function. `npm run lint:fix` and `npm run test` were run successfully to confirm functionality.

---
*PR created automatically by Jules for task [4346385346760650609](https://jules.google.com/task/4346385346760650609) started by @robertsmieja*