### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-06-27 - Log Injection via Unrestricted Mentions
+**Vulnerability:** Discord allows pinging roles (e.g., @everyone) or users. When logs containing user-provided input are sent directly to Discord channels via the transport layer, attackers could perform a log injection attack by inserting mention payloads into their input. The logging framework would dutifully output these mentions, inadvertently pinging large groups of people.
+**Learning:** External services like Discord treat text messages differently than traditional log files by parsing and executing rich features (like mentions). All raw log output sent to such services must explicitly disable these parsing features at the transport boundary to prevent unintentional pings.
+**Prevention:** Universally enforce `allowedMentions: { parse: [] }` in all `discordChannel.send()` payloads, refactoring simple string inputs into explicit message objects.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: Log Injection via Unrestricted Mentions. The discord.js transport layer forwarded log messages directly to the server without explicitly neutralizing message features like mentions. An attacker could craft log payloads (e.g. usernames, error inputs) containing role pings like `@everyone`, causing the logging framework to execute the mention.

🎯 Impact: An attacker could perform large scale notification spam or abuse against developers or other users in the Discord server monitoring the application logs.

🔧 Fix: Replaced simple string transmission with an object payload and universally applied `allowedMentions: { parse: [] }` to the message parameters in `DiscordTransport.ts`, which explicitly blocks the Discord API from parsing any type of ping.

✅ Verification: Tests have been updated and manually run to ensure all `discordChannel.send()` calls expect the new structured payload with `allowedMentions`. Code successfully passes `npm run lint:fix` and `npm test` checks.

---
*PR created automatically by Jules for task [9299790536651648293](https://jules.google.com/task/9299790536651648293) started by @robertsmieja*