### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-23 - Log Injection / Unrestricted Mentions via Discord Transport
+**Vulnerability:** The Winston Discord transport passed string messages directly to `discordChannel.send()` without restricting allowed mentions. This allowed attackers to perform log injection attacks, where maliciously crafted input (e.g. `<@everyone>`) included in logs would trigger unwanted Discord mentions, causing harassment or notification spam.
+**Learning:** External transports (like Discord) that parse and execute commands or mentions within simple strings need explicit restrictions at the transport boundary to prevent log injection from escalating into unwanted side effects.
+**Prevention:** Always explicitly disable mentions by passing `allowedMentions: { parse: [] }` in the Discord message payload, effectively sandboxing log output.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Security: Prevent log injection / unrestricted mentions by explicitly disabling them
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Security: Prevent log injection / unrestricted mentions by explicitly disabling them
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Winston Discord transport passed string messages directly to `discordChannel.send()` without restricting allowed mentions. This allowed attackers to perform log injection attacks, where maliciously crafted input (e.g. `<@everyone>`) included in logs would trigger unwanted Discord mentions, causing harassment or notification spam.
🎯 Impact: Attackers could abuse the logging pipeline to ping `@everyone`, `@here`, or specific users/roles across Discord servers utilizing the logger.
🔧 Fix: Explicitly explicitly disable mentions by passing `allowedMentions: { parse: [] }` in the Discord message payload within `DiscordTransport.ts`.
✅ Verification: Ran `npm run lint:fix && npm run test` locally. The vitest test suite confirms the `send` API receives the correct `allowedMentions` payload structure.

---
*PR created automatically by Jules for task [3196747091881233464](https://jules.google.com/task/3196747091881233464) started by @robertsmieja*