### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** The Discord transport previously sent log messages directly as string content to the Discord API. This meant if an attacker could control parts of the log output (e.g., username, input payload), they could inject `@everyone` or `<@userid>` pings, leading to massive notification spam/abuse on the server.
+**Learning:** External sinks that parse specific tokens (like Discord mentions) treat log content as active commands unless explicitly disabled.
+**Prevention:** All log payload requests sent to Discord should explicitly pass `allowedMentions: { parse: [] }` in the message options to neutralize ping directives, even for simple string-only log emissions.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Log Injection leading to Unrestricted Discord Mentions. The Discord transport directly sent user-controlled log messages as raw strings without disabling Discord's parsing. This allowed attackers to inject `<@userid>` or `@everyone` tokens into logs, potentially resulting in severe notification spam and abuse.
🎯 Impact: Attackers could cause massive notification spam on Discord servers where the bot is integrated by crafting inputs that eventually get logged by Winston.
🔧 Fix: Added `allowedMentions: { parse: [] }` to the Discord API message payload configurations inside `src/DiscordTransport.ts` to neutralize the parsing of all mention tokens entirely. Updated assertions in `src/tests/DiscordTransport.test.ts`. 
✅ Verification: Ran `npm run lint:fix` and `npm run test` successfully. Tests correctly assert that `allowedMentions: { parse: [] }` is included in all invocations to the Discord send function.

---
*PR created automatically by Jules for task [18120115465969462837](https://jules.google.com/task/18120115465969462837) started by @robertsmieja*