### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Log Injection via Unrestricted Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Mention Injection in Logging Transport
+**Vulnerability:** The logger was sending raw log contents to Discord. If an attacker controls the log input (e.g. error messages or web request payload), they can inject tags like `@everyone` or `<@user_id>` causing the logging bot to maliciously ping users.
+**Learning:** External sinks (like Discord or Slack) that parse mentions from messages must have those capabilities explicitly disabled when acting as log aggregators to prevent noise and abuse.
+**Prevention:** Always use `allowedMentions: { parse: [] }` or its equivalent to strip formatting/mentions when sending automated logging messages to a chat API.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The logger was passing raw log contents directly to Discord via `discordChannel.send()`. If an attacker controls input that ends up in a log (e.g., error messages, user IDs, or unhandled exceptions), they could inject Discord tags like `@everyone`, `@here`, or `<@user_id>`, causing the logging bot to maliciously ping users or mass-ping servers.
🎯 Impact: An attacker could perform a "Mention Injection" attack, abusing the bot to create notification spam, ping thousands of users in large servers, or socially engineer admins by making official bots ping them with misleading errors.
🔧 Fix: Refactored `send()` calls in `src/DiscordTransport.ts` to always use a message object and explicitly disable all mention parsing by setting `allowedMentions: { parse: [] }`. This forces Discord to treat all injected tags as plain text, stripping their ability to ping users. Also appended a critical learning to `.jules/sentinel.md`.
✅ Verification: Ran `npm run test` (all 51 tests pass, including the 5 updated mock assertions). Ran `npm run lint:fix` to ensure code formatting remains perfectly compliant. Verified patch application with `git diff`.

---
*PR created automatically by Jules for task [11749637016136304061](https://jules.google.com/task/11749637016136304061) started by @robertsmieja*