### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection via unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-20 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The Discord transport sent log messages directly as strings without setting `allowedMentions`. This allowed any log message containing `@everyone`, `@here`, or role pings to actually trigger notifications in the Discord server, enabling log injection attacks where an attacker could spam server members simply by causing logs with mention tags.
+**Learning:** External communication APIs (like Discord, Slack) often parse raw text for mentions or commands. All programmatic messages sent to these platforms, especially system logs that may include unverified string data, must explicitly disable mention parsing at the transport boundary to prevent abuse.
+**Prevention:** Always explicitly set restrictions like `allowedMentions: { parse: [] }` in the API payload to sanitize outgoing log messages and prevent accidental or malicious mention triggering.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The Discord transport previously sent log messages without setting the `allowedMentions` option. If a log message contained user-controlled strings like `@everyone`, `@here`, or role mentions, Discord's API would parse them as active mentions, triggering notifications. This allowed attackers to perform log injection attacks, exploiting the application's logging infrastructure to spam and abuse Discord server members.

🎯 Impact: Malicious users could bypass the bot's intended permissions by injecting mention tags into log streams (e.g., via failed login attempts, bad requests, or username fields), leading to widespread server disruption, notification spam, and potential abuse of the bot integration.

🔧 Fix: I modified `src/DiscordTransport.ts` to explicitly set `allowedMentions: { parse: [] }` in the message payload passed to `this.discordChannel.send()`. This instructs the Discord API to completely disable mention parsing for the log messages, safely outputting the tags as plain text. The test suite (`src/tests/DiscordTransport.test.ts`) was updated accordingly.

✅ Verification:
1. Ran `npm run lint:fix` and `npm run test` locally to ensure the payload modifications are correctly structured and all tests pass.
2. Ensure that any future calls to `discordChannel.send` within the transport include the `allowedMentions: { parse: [] }` restriction.

---
*PR created automatically by Jules for task [553582581414134742](https://jules.google.com/task/553582581414134742) started by @robertsmieja*