### PR TITLE
🛡️ Sentinel: HIGH Fix Denial of Service in Logging (Primitive info)

### DIFF
--- a/src/LogHandlers.ts
+++ b/src/LogHandlers.ts
@@ -6,7 +6,13 @@ import { LogLevel, LogLevelToColor } from "./LogLevels"
 export const isTransformableInfo = (
   info: unknown
 ): info is TransformableInfo => {
-  return Boolean(info && "level" in (info as any) && "message" in (info as any))
+  // Prevent TypeError when `in` operator is used on primitive values
+  return Boolean(
+    info &&
+      typeof info === "object" &&
+      "level" in (info as any) &&
+      "message" in (info as any)
+  )
 }
 
 const sortFields = (fields: string[]): string[] => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The `isTransformableInfo` type guard used the `in` operator directly on the `info` argument without verifying if `info` was an object. In JavaScript, using the `in` operator on primitive values (like `strings` or `numbers`) throws a `TypeError`. Because `winston-discordjs` formats unknown logging data, an unhandled `TypeError` during serialization would crash the Node.js process.

🎯 Impact: An attacker could intentionally trigger a Denial of Service (DoS) attack, or a "Denial of Logging" attack, by injecting unexpected primitive data into logging streams, causing the host application to crash and effectively hiding their traces.

🔧 Fix: Added a defensive type check (`typeof info === "object" && info !== null`) before the `in` operator evaluations within `isTransformableInfo` to ensure primitives are safely bypassed without throwing exceptions.

✅ Verification: Verified locally that `isTransformableInfo("crash_string")` now safely returns `false` instead of crashing. Ran `npm run lint:fix` and `npm run test` successfully.

---
*PR created automatically by Jules for task [17111018263038310992](https://jules.google.com/task/17111018263038310992) started by @robertsmieja*