### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted discord mentions (log injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-07-05 - Unrestricted Discord Mentions (Log Injection)
+**Vulnerability:** Sending string-based logs directly to the Discord API allows for attackers to inject user mentions, `@everyone`, or `@here` into logs, which would alert users unexpectedly.
+**Learning:** External communication APIs like Discord parse mentions from textual input by default. Logging frameworks should never allow log input to interact with external alerting features such as user mentions unless explicitly desired.
+**Prevention:** Always restrict mentions when submitting payload data to Discord by enforcing `allowedMentions: { parse: [] }` universally at the transport boundary to eliminate "Log Injection" vulnerabilities.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unrestricted mentions (Log Injection). The logging framework was previously passing raw string messages directly to `discordChannel.send()`. Discord parses mentions (e.g., `@everyone`, `@here`, `<@userID>`) from strings by default. An attacker could intentionally trigger logs containing these strings to ping server members maliciously.
🎯 **Impact:** If exploited, attackers could spam a connected Discord channel, sending persistent notifications to all users/roles on the server, causing a denial of service and alert fatigue (Log Injection).
🔧 **Fix:** Refactored the `discordChannel.send()` calls to always use an object payload and explicitly set `allowedMentions: { parse: [] }`. This prevents the Discord API from resolving any text into an actionable ping, neutralizing the log injection vector.
✅ **Verification:** Verified via updated unit tests in `DiscordTransport.test.ts` that ensure all invocations of `.send()` strictly receive the `allowedMentions` payload config. Tests successfully pass using `npm run test` and `npm run lint:fix`.

---
*PR created automatically by Jules for task [5256852259561850078](https://jules.google.com/task/5256852259561850078) started by @robertsmieja*