### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unintended Discord Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-13 - Security Improvement: Prevention of unintended pings/mentions in Discord
+**Vulnerability:** Discord allows pinging/mentioning users using formatted text like `<@userid>`. If these are included inside logged objects, attackers could trigger unintended pings, leading to spam.
+**Learning:** Always restrict user-provided input from turning into actionable actions outside the application.
+**Prevention:** Explicitly restrict parsing of mentions when making external service requests that support such functionality unless explicitly desired. In this project, that's done by adding `allowedMentions: { parse: [] }` in the Discord payload.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The DiscordTransport implementation was sending unmitigated log payloads to Discord channels. Because Discord allows pinging/mentioning users using formatted text like `<@userid>`, any logged string or object field matching this format could trigger unintended user mentions or `@everyone`/`@here` pings, leading to potential notification spam attacks (Log Injection).

🎯 Impact: An attacker could intentionally trigger spam pings in the integrated Discord server by providing malicious payload content (like an abusive username or specific input field) that the application logs.

🔧 Fix: Explicitly configured the Discord channel send payload to restrict parsing mentions by adding `allowedMentions: { parse: [] }`. For the `string` log path, it was refactored to pass an object payload with `content` to accommodate the new options without breaking the integration.

✅ Verification: Tested against existing unit tests (updated to assert the new `{ content, allowedMentions }` payload format) and ensured both string messages and embedded messages explicitly set the mention-restriction option. Tests and linting completed via `npm run test` and `npm run lint:fix`.

---
*PR created automatically by Jules for task [17006210824720881690](https://jules.google.com/task/17006210824720881690) started by @robertsmieja*