### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-13 - Unrestricted Discord Mentions in Log Payloads
+**Vulnerability:** Discord transport sent log messages without disabling mentions. If an attacker controlled logged content (like username or input), they could inject `@everyone` or `@here` and mass-ping the server.
+**Learning:** External integrations like Discord that support notification pings must explicitly disable mentions by default to prevent attackers from weaponizing logs to ping administrators or entire communities.
+**Prevention:** Always set `allowedMentions: { parse: [] }` for all payloads sent via the Discord API to prevent unintended mentions.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Discord transport sent log messages without disabling mentions. If an attacker controlled logged content (such as a username or input payload), they could inject `@everyone` or `@here` and mass-ping the server or administrators via the logging system.
🎯 **Impact:** Malicious log injection could be weaponized to cause a Denial of Service (DoS) through notification spam or social engineering against server staff.
🔧 **Fix:** Refactored `.send()` calls to explicitly set `allowedMentions: { parse: [] }`, forcing the Discord API to treat all mentions in the payload as plain text and preventing notifications.
✅ **Verification:** Added/updated unit tests in `DiscordTransport.test.ts` to expect the `allowedMentions` object, ensuring mentions remain disabled. Ran `npm run test` to verify all tests pass.

---
*PR created automatically by Jules for task [11410263879216279369](https://jules.google.com/task/11410263879216279369) started by @robertsmieja*