### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Discord Mentions (Log Injection)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-07-10 - Unrestricted Discord Mentions (Log Injection)
+**Vulnerability:** Discord allows pinging/mentioning users and roles (e.g., `@everyone`) within message content. The logging transport did not restrict parsing of mentions, allowing maliciously crafted log messages to trigger unauthorized notifications and mention spam.
+**Learning:** External notification and logging services with mention capabilities must strictly define and restrict mention parsing to avoid log injection vulnerabilities leading to spam or harassment.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or similar settings) when calling transport APIs like Discord to completely disable mention parsing for all user-provided log content.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] }
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The Discord logging transport did not restrict mention parsing when sending log messages to the Discord API. This creates a "Log Injection" vulnerability where maliciously crafted logs containing ping tags (like `@everyone` or `<@userid>`) can trigger unauthorized notifications and mention spam in the connected Discord channel.
🎯 **Impact**: If exploited by an attacker submitting malicious input that is subsequently logged, it could lead to severe notification spam and harassment in the configured channel, bypassing intended moderation or server settings.
🔧 **Fix**: Refactored the `discordChannel.send()` calls in `src/DiscordTransport.ts` to always pass an object payload with `allowedMentions: { parse: [] }`. This explicitly instructs the Discord API to never parse mentions from the provided log content. Unit tests were updated to assert against this new object structure.
✅ **Verification**: Verified fix via locally executed unit tests (`npm run test`) and format checks (`npm run lint:fix`), all of which passed successfully.

---
*PR created automatically by Jules for task [8678859650477303663](https://jules.google.com/task/8678859650477303663) started by @robertsmieja*