### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-10-24 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** The Discord transport failed to disable mention parsing, meaning an attacker who controls logged input could inject @everyone, @here, or role mentions.
+**Learning:** External integrations like Discord parse mentions by default. Sending unsanitized log content to Discord without restricting mention parsing allows attackers to ping users/roles in the Discord server where logs are sent.
+**Prevention:** Always set `allowedMentions: { parse: [] }` when sending payloads to Discord API, converting simple string content into object payloads when necessary to apply this restriction.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: 
The Discord transport was sending logs to the `TextChannel.send()` method without restricting mention parsing. By default, Discord automatically parses `@everyone`, `@here`, `@user`, and `@role` mentions found in standard message text. If an attacker controls input that is subsequently logged (e.g., via user-agent injection, request paths, or user-supplied usernames), they can arbitrarily ping roles and users in the destination server where logs are delivered.

🎯 **Impact**:
An attacker could cause significant nuisance (Denial of Service/Spam) or social engineering by injecting `@everyone` or `@here` mentions into logs. In servers with large member counts or critical monitoring channels, this can severely disrupt operations or allow for targeted harassment.

🔧 **Fix**:
All `discordChannel.send()` calls in `src/DiscordTransport.ts` have been updated to explicitly pass the `allowedMentions: { parse: [] }` option. For string-only log messages, the invocation was refactored into the equivalent object payload `{ content: logMessage, allowedMentions: { parse: [] } }`. 

✅ **Verification**:
- `npm run lint:fix` and `npm run test` were verified successfully in the CI sandbox.
- `DiscordTransport.test.ts` was updated to explicitly assert that the mock channel `.send` method is always called with `allowedMentions: { parse: [] }`.

---
*PR created automatically by Jules for task [7617357955385265857](https://jules.google.com/task/7617357955385265857) started by @robertsmieja*