### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Service risk via unhandled login promise rejection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-07-12 - Denial of Service via Unhandled Promise Rejections
+**Vulnerability:** External asynchronous calls, specifically `discordClient.login()`, were executed without attached `.catch()` handlers.
+**Learning:** Unhandled promise rejections can crash modern Node.js processes, creating a Denial of Service (DoS) vulnerability.
+**Prevention:** Always attach `.catch()` blocks to asynchronous external operations to fail safely without bringing down the host application.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -33,7 +33,9 @@ export class DiscordTransport extends TransportStream {
           this.discordClient.on("error", (error) => {
             this.emit("warn", error)
           })
-          this.discordClient.login(discordToken)
+          this.discordClient.login(discordToken).catch((error) => {
+            this.emit("warn", error)
+          })
         }
       }
 

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -4,7 +4,18 @@ import DiscordTransport, {
 } from "../DiscordTransport"
 import * as Discord from "discord.js"
 
-vi.mock("discord.js")
+vi.mock("discord.js", async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    Client: vi.fn(function (this: any, options: any) {
+      this.login = vi.fn(() => Promise.resolve("token"))
+      this.on = vi.fn()
+      this.destroy = vi.fn()
+      return this
+    }),
+  }
+})
 
 describe("DiscordTransport", () => {
   describe("constructor", () => {
@@ -34,7 +45,7 @@ describe("DiscordTransport", () => {
       const fakeChannelManager = {} as Partial<Discord.ChannelManager>
 
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
       fakeDiscordClient.channels = fakeChannelManager as Discord.ChannelManager
@@ -67,13 +78,15 @@ describe("DiscordTransport", () => {
 
       // Recreate how discordClient is handled in the previous test
       const fakeDiscordClient = {
-        login: vi.fn(),
+        login: vi.fn(() => Promise.resolve("token")),
         on: vi.fn(),
       } as Partial<Discord.Client>
 
       // temporarily override the mock so we control `on`
       vi.spyOn(Discord, "Client").mockImplementationOnce(function (this: any) {
-        return fakeDiscordClient as any
+        this.login = fakeDiscordClient.login
+        this.on = fakeDiscordClient.on
+        return this as any
       } as any)
 
       const transport = new DiscordTransport(options)


### PR DESCRIPTION
### 🚨 Severity
HIGH

### 💡 Vulnerability
External asynchronous calls, specifically the `this.discordClient.login()` call in `DiscordTransport.ts`, were executed without attached `.catch()` handlers. In modern Node.js environments (v15+), unhandled promise rejections result in the process exiting with a non-zero status code (a fatal crash). 

### 🎯 Impact
If the Discord API is unreachable due to network conditions, or if the provided token becomes invalid, the unhandled promise rejection thrown by the Discord.js client would instantly crash the entire parent Node.js application. Since this library is a logging transport, crashing the host application due to a logging failure constitutes a Denial of Service (DoS) vulnerability.

### 🔧 Fix
1. Attached a `.catch()` block to the `this.discordClient.login(discordToken)` call to safely trap any initialization errors.
2. Routed the trapped error cleanly through the transport's standard `this.emit("warn", error)` pattern, adhering to Winston-like fallback behavior.
3. Updated the `discord.js` mock in Vitest (`vi.mock` factory) to correctly simulate that `login()` returns a resolved Promise, preventing tests from breaking.

### ✅ Verification
1. Run `npm test` locally to ensure the Vitest suite passes entirely (specifically the constructor mocking tests for `discordClient`).
2. Run `npm run lint:fix` to ensure no unused variable warnings or ESLint/Prettier violations are present.
3. Both run successfully and tests pass 100%.

---
*PR created automatically by Jules for task [8674415262952741886](https://jules.google.com/task/8674415262952741886) started by @robertsmieja*