### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unrestricted mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-02-12 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** Unrestricted mentions in Discord messages (e.g., `@everyone`, `@here`, role mentions) could be triggered by an attacker injecting malicious payloads into application logs, causing the logging transport to ping all users in the Discord channel.
+**Learning:** External transport integrations that support rich formatting or mentions (like Discord) will parse mentions from raw string contents by default, turning log injection into a notification spam/DoS vector.
+**Prevention:** Always disable mention parsing at the transport boundary by explicitly setting `allowedMentions: { parse: [] }` in the API payload when dispatching log messages.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM. 💡 Vulnerability: Unrestricted mentions in Discord messages could be triggered by injecting malicious payloads into application logs. 🎯 Impact: Attackers could ping all users in the Discord channel (e.g., @everyone), causing notification spam and potential DoS. 🔧 Fix: Explicitly set `allowedMentions: { parse: [] }` in the message options for all payloads sent via the Discord transport. ✅ Verification: Checked via tests verifying the `allowedMentions` payload option is present.

---
*PR created automatically by Jules for task [18386504823348667786](https://jules.google.com/task/18386504823348667786) started by @robertsmieja*