### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** Discord's default behavior allows any text mentioning a user, role, or @everyone/@here to trigger a notification. By injecting mentions into log messages, an attacker could abuse the logging transport to ping arbitrary users or groups in Discord (Denial of Service/Spam).
+**Learning:** Logging integrations that send user-controlled or arbitrary data to Discord must explicitly disable mention parsing to prevent "Log Injection" vulnerabilities from causing unintended notifications or spam.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in the payload when sending messages via Discord API integrations to explicitly restrict parsing mentions from arbitrary text.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Prevent arbitrary pinging/mentions via log messages
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Prevent arbitrary pinging/mentions via log messages
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Discord's default behavior allows any text containing a user mention, role mention, or @everyone/@here to trigger a notification when sent via the API. By injecting such mentions into log messages, an attacker could abuse the logging transport to ping arbitrary users or groups in Discord (Denial of Service/Spam).
🎯 Impact: A malicious actor could flood the Discord server with unwanted notifications, causing a Denial of Service via notification spam, or socially engineer users by making official logs appear to tag them directly.
🔧 Fix: Explicitly disabled all mention parsing for messages sent by the transport by adding `allowedMentions: { parse: [] }` to the `discordChannel.send()` payload, converting string payloads to objects where necessary.
✅ Verification: Ran `npm run lint:fix` and `npm run test` (Vitest), and verified all tests pass with updated assertions that check for the `allowedMentions` property in the mocked `send` payloads.

---
*PR created automatically by Jules for task [13089649903343858304](https://jules.google.com/task/13089649903343858304) started by @robertsmieja*