### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** The Discord transport sent log messages directly to channels without setting `allowedMentions: { parse: [] }`. This allowed malicious actors to inject `@everyone`, `@here`, or role mentions into log messages, which would be parsed and pinged by Discord, leading to notification spam and potential social engineering attacks.
+**Learning:** External integrations that parse rich text or mentions (like Discord or Slack) must always have mention parsing explicitly disabled when handling untrusted or arbitrary log data to prevent log injection attacks.
+**Prevention:** Always enforce strict allowed mentions policies (e.g., `allowedMentions: { parse: [] }`) on all outgoing API calls that support mention parsing, especially when the payload includes stringified external data.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The Discord transport sent log messages directly to channels without setting `allowedMentions: { parse: [] }`. This allowed malicious actors to inject `@everyone`, `@here`, or role mentions into log messages, which would be parsed and pinged by Discord, leading to notification spam and potential social engineering attacks.

🎯 Impact: An attacker could potentially abuse logging to mass-ping members of a Discord server, leading to severe notification fatigue and potentially using the application's trusted authority for social engineering.

🔧 Fix: Updated the message sending logic in `src/DiscordTransport.ts` to explicitly set `allowedMentions: { parse: [] }` in all outgoing payloads, ensuring that mentions in log messages are parsed merely as raw text and do not trigger notifications. Updated the test suite to match.

✅ Verification: Run `npm run lint:fix && npm run test` to ensure tests pass and code style is maintained.

---
*PR created automatically by Jules for task [9387434768260731818](https://jules.google.com/task/9387434768260731818) started by @robertsmieja*