### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unrestricted mentions vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2025-03-05 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** The Winston transport forwarded plain string logs directly to the Discord API without restricting mentions, allowing malicious inputs to ping @everyone or other roles.
+**Learning:** Sending unsanitized strings directly to Discord messaging APIs creates a vulnerability where attackers can cause notification spam or target specific users through log injection.
+**Prevention:** Always explicitly set `allowedMentions: { parse: [] }` in Discord API message payloads, even for simple string messages, to disable mention parsing.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -53,15 +53,20 @@ export class DiscordTransport extends TransportStream {
 
       if (this.discordChannel && logMessage) {
         let messagePromise: Promise<Message>
+        // Security: Prevent log injection mentions
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability: The Winston transport forwarded plain string logs directly to the Discord API without restricting mentions. This creates a Log Injection vulnerability where malicious inputs (e.g., `@everyone`) within the log output could inadvertently ping users and roles on the destination Discord server.

🎯 Impact: Attackers could inject mentions into logs, causing notification spam or targeting specific users, turning a logging utility into an annoying nuisance or social engineering vector.

🔧 Fix: Explicitly set `allowedMentions: { parse: [] }` on all Discord API message payloads. For plain string logs, the `send` argument was refactored into an object payload `{ content: logMessage, allowedMentions: { parse: [] } }`.

✅ Verification: Verified the fix by successfully running the unit test suite (`npm run test`) after updating the `toHaveBeenCalledWith` assertions to expect the new `.send` payload structures with `allowedMentions`.

---
*PR created automatically by Jules for task [15807727680681176179](https://jules.google.com/task/15807727680681176179) started by @robertsmieja*