### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection and mention spam

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+## 2025-02-12 - Log Injection and Mention Spams
+**Vulnerability:** Discord allows pinging/mentioning users and roles like `@everyone` or `@here` via messages. If an attacker controls part of the logged message, they can cause log-injection in the target Discord channel which results in unwanted and malicious pings.
+**Learning:** For Discord Transports, mentions need to be strictly controlled, restricted, and explicitly parsed or disabled if the underlying framework allows any external log values to feed into the Discord API payloads.
+**Prevention:** Explicitly pass `allowedMentions: { parse: [] }` on any `.send()` Discord payload that originates from untrusted logs.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,13 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage as string,
+            allowedMentions: { parse: [] }, // Security: Prevent log injection mentions
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Discord allows pinging/mentioning users and roles like `@everyone` or `@here` via messages. If an attacker controls part of the logged message, they can cause log-injection in the target Discord channel which results in unwanted and malicious pings.
🎯 **Impact:** An attacker could spam Discord channels with mentions, causing annoyance, alert fatigue, or potentially masking real issues by flooding the channel with pings, leading to a degraded monitoring experience.
🔧 **Fix:** Explicitly pass `allowedMentions: { parse: [] }` on any `.send()` Discord payload that originates from untrusted logs, converting simple string payloads to the object format to support this option.
✅ **Verification:** Verified by ensuring unit tests pass after updating the mocks to expect the newly added `allowedMentions` object, and verified the build via ESLint and Vitest.

---
*PR created automatically by Jules for task [11991091795947845868](https://jules.google.com/task/11991091795947845868) started by @robertsmieja*