### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions and log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Discord Mentions via Log Injection
+**Vulnerability:** Log messages sent to the Discord API did not explicitly restrict mention parsing. An attacker could inject `@everyone`, `@here`, or specific user/role IDs into the log content, causing the Discord bot to ping users maliciously when the log is delivered.
+**Learning:** External APIs that parse content for mentions or pings must be configured to disable this behavior for untrusted or dynamic content, especially in logging frameworks where the payload is partially or entirely user-controlled.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or the equivalent API option) in the message payload when sending log data or other unverified content to platforms like Discord.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -56,12 +56,15 @@ export class DiscordTransport extends TransportStream {
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
+          // Security: Prevent log injection and unrestricted mentions
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Security: Prevent log injection and unrestricted mentions
+          messagePromise = this.discordChannel.send({ content: logMessage, allowedMentions: { parse: [] } })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH 💡 Vulnerability: Log messages sent to Discord didn't explicitly restrict user/role mentions, allowing attackers to perform log injection attacks causing mass unwanted pings. 🎯 Impact: An attacker could craft payloads that trigger mass Discord notifications to @everyone, @here, or specific users/roles. 🔧 Fix: Refactored message payloads to explicitly set allowedMentions: { parse: [] } to disable mention parsing. ✅ Verification: Run npm test.

---
*PR created automatically by Jules for task [424185807946832885](https://jules.google.com/task/424185807946832885) started by @robertsmieja*