### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Mentions via Log Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Mentions via Log Injection
+**Vulnerability:** Discord's API parses and triggers mentions (e.g., `@everyone`, `@here`) in log messages sent by the transport if not explicitly disabled. An attacker could exploit this by injecting mention strings into log outputs to cause notification spam.
+**Learning:** External communication APIs (like Discord, Slack) often support rich text formatting and mentions by default. Sending unsanitized log content to these APIs without disabling parsing features creates a log injection vulnerability.
+**Prevention:** Always explicitly set `allowedMentions: { parse: [] }` (or the equivalent API property) when sending automated logs or simple strings to messaging platforms to prevent arbitrary mentions from being triggered.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -56,12 +56,18 @@ export class DiscordTransport extends TransportStream {
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
+          // Security: Prevent unrestricted mentions
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          // Security: Prevent unrestricted mentions
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Discord transport previously sent text content exactly as-is to the Discord channel, relying on standard text behavior. By default, Discord's API parses and triggers mentions (e.g. `@everyone`, `<@123>`) if they are present in the text, meaning an attacker could log injection payloads to arbitrarily ping Discord users and roles via the application's logging stream.
🎯 Impact: An attacker could trigger notification spam, ping `@everyone` repeatedly, or harass specific users, leading to Denial of Service (DoS) of the monitoring channel or alerting fatigue that obscures real incidents.
🔧 Fix: Explicitly enforce `{ allowedMentions: { parse: [] } }` on all payloads dispatched to `discordChannel.send()` to instruct Discord to ignore and suppress any raw mention strings in the text content, completely neutralizing log injection risks for mentions.
✅ Verification: Ran `npm run lint:fix` and `npm run test` confirming that unit tests expect the updated `{ allowedMentions: { parse: [] } }` behavior without any regressions to core transport logic.

---
*PR created automatically by Jules for task [4253177261288735688](https://jules.google.com/task/4253177261288735688) started by @robertsmieja*