### PR TITLE
🛡️ Sentinel: [HIGH] Fix unrestricted Discord mentions via log injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+## 2024-05-24 - Log Injection leading to Unrestricted Mentions
+**Vulnerability:** Discord's API parses mentions (e.g. `@everyone`) by default. The transport sent raw log messages directly, meaning an attacker who controls log input could inject mentions and mass-ping Discord users, potentially causing a Denial of Service via notification spam.
+**Learning:** Any content sent to communication platforms (like Discord or Slack) must explicitly disable automatic mention parsing unless specifically required by the application logic.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in the payload when sending automated messages to external platforms to prevent mention abuse via log injection.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Security: Prevent unrestricted Discord mentions via log injection
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Security: Prevent unrestricted Discord mentions via log injection
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Discord's API parses mentions (like `@everyone` or `@here`) by default in message content. The Winston transport was sending log messages directly without restricting mention parsing. An attacker capable of injecting text into logs (e.g., via user input that gets logged) could craft payloads that trigger mass notifications to users or roles in the Discord server, leading to a notification spam Denial of Service (DoS) attack.
🎯 **Impact**: If exploited, attackers could spam the Discord server with `@everyone`, `@here`, or specific user/role pings, causing significant disruption to developers and server members monitoring the logging channel.
🔧 **Fix**: Refactored the `send()` calls in `src/DiscordTransport.ts` to explicitly use the object payload format and include `allowedMentions: { parse: [] }`. This instructs the Discord API to never parse any mentions within the log message, neutralizing the injection attack vector. Added inline security comments to explain the restriction.
✅ **Verification**: Verified that all unit tests in `src/tests/DiscordTransport.test.ts` pass after being updated to expect the new payload format containing `allowedMentions: { parse: [] }`. Executed `npm run lint:fix` and `npm run test` locally to ensure no regressions. Also added a critical learning entry to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [17060008011012793948](https://jules.google.com/task/17060008011012793948) started by @robertsmieja*