### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Log Injection & Unrestricted Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Mentions via Log Injection
+**Vulnerability:** Discord API parses and triggers mentions (e.g. `@everyone`, `@here`, `<@userId>`) when they are included in message content. Without `allowedMentions: { parse: [] }`, an attacker can include mention strings in their input (which gets logged), causing the logging bot to constantly ping server members.
+**Learning:** External transports like Discord must explicitly disable notification/mention parsing for log payloads. Otherwise, simple log injections escalate into targeted harassment or denial-of-service against chat participants.
+**Prevention:** Always set `allowedMentions: { parse: [] }` in the message options for Discord integrations, especially when logging user-controlled input.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -59,9 +59,15 @@ export class DiscordTransport extends TransportStream {
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            // Security: Prevent log injection and unrestricted mentions
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            // Security: Prevent log injection and unrestricted mentions
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Log Injection leading to Unrestricted Mentions (Targeted Harassment/DoS). The transport previously sent logs to Discord without explicit `allowedMentions` options. Since Discord parses mentions by default, an attacker could include mention syntax (like `@everyone` or `<@userId>`) in user-controlled input that gets logged, causing the bot to constantly ping server members.
🎯 Impact: Attackers can weaponize the logging bot to mass-ping and harass Discord users, effectively causing a notification denial-of-service on the server.
🔧 Fix: Updated the message payload in `src/DiscordTransport.ts` to include `allowedMentions: { parse: [] }`. This universally prevents the Discord API from parsing or triggering mentions for any string inside the log content. Also updated all associated tests in `src/tests/DiscordTransport.test.ts` to ensure mocking compatibility.
✅ Verification: Ran `npm run lint:fix && npm run test` to ensure formatting and code integrity. Tests verify the correct payload containing `allowedMentions` is dispatched via the mocked send method.

---
*PR created automatically by Jules for task [2490347757099553929](https://jules.google.com/task/2490347757099553929) started by @robertsmieja*