### PR TITLE
🛡️ Sentinel: [HIGH] Fix log injection by disabling mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-08-14 - Log Injection via Unrestricted Discord Mentions
+**Vulnerability:** Sending raw string logs directly to Discord allowed attackers to include mention syntax (e.g., @everyone, @here, or role/user IDs) in their inputs, causing the bot to unexpectedly mention users and groups when logging malicious events.
+**Learning:** External transport integrations that send data as user-visible messages (like Discord or Slack) must explicitly disable formatting or mention parsing to prevent "Log Injection" or "Notification Spam".
+**Prevention:** Always set explicit payload options (e.g., `allowedMentions: { parse: [] }`) when sending user-controlled data to Discord to ensure mentions are strictly suppressed across all execution paths.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -53,15 +53,20 @@ export class DiscordTransport extends TransportStream {
 
       if (this.discordChannel && logMessage) {
         let messagePromise: Promise<Message>
+        // Security: Disable mentions to prevent log injection
         if (Array.isArray(logMessage)) {
           const content = logMessage[0]
           const embed = logMessage[1]
           messagePromise = this.discordChannel.send({
             content,
             embeds: [embed],
+            allowedMentions: { parse: [] },
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH. 
💡 Vulnerability: Attackers can inject Discord mention syntax (@everyone, @here, etc.) into log messages, causing the logging bot to unexpectedly ping users and roles when recording logs containing user-controlled input. 
🎯 Impact: Notification spam and potential social engineering attacks against server members. 
🔧 Fix: Refactored message sending logic to always explicitly pass `allowedMentions: { parse: [] }` in all Discord payloads to strictly disable mention parsing across all execution paths. 
✅ Verification: Ran `npm run test` to verify payload options are successfully updated and behavior is consistent.

---
*PR created automatically by Jules for task [2381624929474162449](https://jules.google.com/task/2381624929474162449) started by @robertsmieja*