### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unrestricted Mentions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Maliciously crafted prototype-less objects (e.g. `Object.create(null)`) or objects that intentionally throw errors in `.toString()` caused the logging framework to crash the Node process when it attempted to serialize log messages via direct string interpolation.
 **Learning:** String interpolation or `.toString()` calls on arbitrary external data should never be trusted, especially in a logging path where "Denial of Logging" attacks can occur by silently triggering unhandled exceptions.
 **Prevention:** Implement a robust fallback serialization mechanism (like `safeStringify` combining `String()`, `JSON.stringify()`, and hardcoded defaults inside `try-catch` blocks) before formatting objects for logging transport payloads.
+
+## 2024-05-18 - Unrestricted Mentions in Discord Transport
+**Vulnerability:** The Discord transport sent log messages directly to channels without restricting mentions. An attacker who could inject arbitrary text into logs could use this to ping @everyone, @here, or specific users/roles.
+**Learning:** External communication integrations (like Discord, Slack) that support mentions must explicitly disable mention parsing by default for log contents to prevent log injection from being weaponized.
+**Prevention:** Always set `allowedMentions: { parse: [] }` (or equivalent API options) on automated bot or logging integrations unless specific mentions are strictly required and sanitized.

--- a/src/DiscordTransport.ts
+++ b/src/DiscordTransport.ts
@@ -57,11 +57,15 @@ export class DiscordTransport extends TransportStream {
           const content = logMessage[0]
           const embed = logMessage[1]
           messagePromise = this.discordChannel.send({
+            allowedMentions: { parse: [] },
             content,
             embeds: [embed],
           })
         } else {
-          messagePromise = this.discordChannel.send(logMessage)
+          messagePromise = this.discordChannel.send({
+            content: logMessage,
+            allowedMentions: { parse: [] },
+          })
         }
         messagePromise.catch((error) => {
           this.emit("warn", error)

--- a/src/tests/DiscordTransport.test.ts
+++ b/src/tests/DiscordTransport.test.ts
@@ -135,7 +135,10 @@ describe("DiscordTransport", () => {
         Discord.TextChannel["send"]
       >
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     it("handles log messages with embeds correctly", () => {
@@ -155,6 +158,7 @@ describe("DiscordTransport", () => {
       expect(mockSend).toHaveBeenCalledWith({
         content: "Level: info, Message: log me!",
         embeds: [expect.any(Discord.MessageEmbed)],
+        allowedMentions: { parse: [] },
       })
     })
 
@@ -176,7 +180,10 @@ describe("DiscordTransport", () => {
         transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
         transport.on("warn", (error) => {
           expect(error).toStrictEqual(fakeError)
-          expect(mockSend).toHaveBeenCalledWith("log me!")
+          expect(mockSend).toHaveBeenCalledWith({
+            content: "log me!",
+            allowedMentions: { parse: [] },
+          })
           resolve()
         })
         transport.log("log me!", undefined)
@@ -202,7 +209,10 @@ describe("DiscordTransport", () => {
       transport.discordChannel = fakeDiscordChannel as Discord.TextChannel
       transport.log("log me!", callback)
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
       expect(callback).toHaveBeenCalledTimes(1)
     })
 
@@ -223,7 +233,10 @@ describe("DiscordTransport", () => {
         transport.log("log me!", {} as any)
       }).not.toThrow()
 
-      expect(mockSend).toHaveBeenCalledWith("log me!")
+      expect(mockSend).toHaveBeenCalledWith({
+        content: "log me!",
+        allowedMentions: { parse: [] },
+      })
     })
 
     describe("close()", () => {


### PR DESCRIPTION
🚨 Severity: HIGH 💡 Vulnerability: Log messages sent to Discord did not restrict mentions, allowing log injection to ping @everyone, @here, or specific roles/users. 🎯 Impact: An attacker could perform log injection to spam mentions, causing annoyance or social engineering attacks. 🔧 Fix: Explicitly set allowedMentions: { parse: [] } on all messages sent to the Discord transport. ✅ Verification: Ensure npm test passes.

---
*PR created automatically by Jules for task [450236922580753527](https://jules.google.com/task/450236922580753527) started by @robertsmieja*